### PR TITLE
feat adding stdio mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Variables are substituted from `UtcpClientConfig::variables` or environment vari
 - `cargo run --example load_from_json` — load providers from `examples/providers.json`.
 - `cargo run --example http_server` — demo HTTP provider + client.
 - `cargo run --example websocket_server` / `sse_server` / `tcp_server` / `udp_server` / `http_stream_server` / `grpc_server` / `graphql_server` / `mcp_server` — self-hosted provider for each transport.
+- `cargo run --example mcp_stdio` — MCP stdio transport with a Python calculator server (see [MCP_STDIO_README.md](examples/MCP_STDIO_README.md)).
 - `cargo run --example cli_program` — treat the binary as its own CLI provider.
 - `cargo run --example codemode_eval` — evaluate Rust-like snippets (Rhai) that can call UTCP tools.
 - `cargo run --example all_providers` — env-driven sampler for every transport (set `DEMO_*` vars).

--- a/examples/mcp_server/main.rs
+++ b/examples/mcp_server/main.rs
@@ -5,8 +5,6 @@ use hyper::{Body, Method, Request, Response, Server, StatusCode};
 use rs_utcp::UtcpClientInterface;
 use serde_json::json;
 
-#[path = "../common/mod.rs"]
-mod common;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/mcp_stdio.rs
+++ b/examples/mcp_stdio.rs
@@ -1,0 +1,80 @@
+// Example: Using MCP stdio transport
+//
+// This example demonstrates how to use the MCP transport with stdio communication.
+// It spawns an MCP server as a child process and communicates with it over stdin/stdout.
+
+use rs_utcp::UtcpClientInterface;
+use serde_json::json;
+use std::collections::HashMap;
+
+#[path = "common/mod.rs"]
+mod common;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    println!("🚀 MCP Stdio Transport Example\n");
+    
+    // Example 1: Using MCP stdio with node (if you have an MCP server)
+    // Uncomment this if you have a real MCP server installed
+    /*
+    let client = common::client_from_providers(json!({
+        "providers": [{
+            "provider_type": "mcp",
+            "name": "filesystem",
+            "command": "node",
+            "args": ["/path/to/mcp-server/index.js"],
+            "env_vars": {
+                "MCP_DEBUG": "1"
+            }
+        }]
+    }))
+    .await?;
+    */
+    
+    // Example 2: Using the example stdio MCP server (Python)
+    // First, run: python examples/mcp_stdio_server.py
+    println!("📡 Creating UTCP client with MCP stdio provider");
+    let client = common::client_from_providers(json!({
+        "providers": [{
+            "provider_type": "mcp",
+            "name": "calculator",
+            "command": "python3",
+            "args": ["examples/mcp_stdio_server.py"]
+        }]
+    }))
+    .await?;
+    
+    println!("✓ UTCP Client initialized with MCP stdio transport\n");
+    
+    // List available tools from the stdio MCP server
+    println!("📋 Listing available tools:");
+    let tools = client.search_tools("", 10).await?;
+    for tool in &tools {
+        println!("  • {}: {}", tool.name, tool.description);
+    }
+    
+    // Example 3: Call a tool via stdio
+    println!("\n⚡ Calling 'add' tool:");
+    let mut args = HashMap::new();
+    args.insert("a".to_string(), json!(5));
+    args.insert("b".to_string(), json!(3));
+    
+    let result = client.call_tool("calculator.add", args).await?;
+    println!("  Result: {}", serde_json::to_string_pretty(&result)?);
+    
+    // Example 4: Call another tool
+    println!("\n⚡ Calling 'multiply' tool:");
+    let mut args2 = HashMap::new();
+    args2.insert("a".to_string(), json!(7));
+    args2.insert("b".to_string(), json!(6));
+    
+    let result2 = client.call_tool("calculator.multiply", args2).await?;
+    println!("  Result: {}", serde_json::to_string_pretty(&result2)?);
+    
+    println!("\n✨ Demo complete!");
+    println!("\nNote: MCP stdio transport communicates with processes via stdin/stdout");
+    println!("      This is useful for local tools, sandboxed environments, and");
+    println!("      language-agnostic tool providers.");
+    
+    Ok(())
+}

--- a/examples/mcp_stdio_server.py
+++ b/examples/mcp_stdio_server.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+Simple MCP (Model Context Protocol) stdio server example.
+
+This is a minimal MCP server that communicates over stdin/stdout using JSON-RPC 2.0.
+It implements a basic calculator with add, subtract, multiply, and divide operations.
+"""
+
+import sys
+import json
+
+
+def handle_tools_list(request_id):
+    """Return the list of available tools."""
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "result": {
+            "tools": [
+                {
+                    "name": "add",
+                    "description": "Add two numbers",
+                    "inputs": {
+                        "type": "object",
+                        "properties": {
+                            "a": {"type": "number", "description": "First number"},
+                            "b": {"type": "number", "description": "Second number"}
+                        },
+                        "required": ["a", "b"]
+                    },
+                    "outputs": {"type": "number"},
+                    "tags": ["math", "calculator"]
+                },
+                {
+                    "name": "subtract",
+                    "description": "Subtract two numbers",
+                    "inputs": {
+                        "type": "object",
+                        "properties": {
+                            "a": {"type": "number", "description": "First number"},
+                            "b": {"type": "number", "description": "Second number"}
+                        },
+                        "required": ["a", "b"]
+                    },
+                    "outputs": {"type": "number"},
+                    "tags": ["math", "calculator"]
+                },
+                {
+                    "name": "multiply",
+                    "description": "Multiply two numbers",
+                    "inputs": {
+                        "type": "object",
+                        "properties": {
+                            "a": {"type": "number", "description": "First number"},
+                            "b": {"type": "number", "description": "Second number"}
+                        },
+                        "required": ["a", "b"]
+                    },
+                    "outputs": {"type": "number"},
+                    "tags": ["math", "calculator"]
+                },
+                {
+                    "name": "divide",
+                    "description": "Divide two numbers",
+                    "inputs": {
+                        "type": "object",
+                        "properties": {
+                            "a": {"type": "number", "description": "Numerator"},
+                            "b": {"type": "number", "description": "Denominator"}
+                        },
+                        "required": ["a", "b"]
+                    },
+                    "outputs": {"type": "number"},
+                    "tags": ["math", "calculator"]
+                }
+            ]
+        }
+    }
+
+
+def handle_tools_call(request_id, params):
+    """Execute a tool call."""
+    tool_name = params.get("name")
+    arguments = params.get("arguments", {})
+    
+    try:
+        a = arguments.get("a")
+        b = arguments.get("b")
+        
+        if a is None or b is None:
+            return {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {
+                    "code": -32602,
+                    "message": "Missing required arguments 'a' and 'b'"
+                }
+            }
+        
+        # Perform the calculation
+        if tool_name == "add":
+            result = a + b
+        elif tool_name == "subtract":
+            result = a - b
+        elif tool_name == "multiply":
+            result = a * b
+        elif tool_name == "divide":
+            if b == 0:
+                return {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "error": {
+                        "code": -32000,
+                        "message": "Division by zero"
+                    }
+                }
+            result = a / b
+        else:
+            return {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {
+                    "code": -32601,
+                    "message": f"Unknown tool: {tool_name}"
+                }
+            }
+        
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "result": result,
+                "tool": tool_name,
+                "arguments": arguments
+            }
+        }
+    except Exception as e:
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {
+                "code": -32000,
+                "message": str(e)
+            }
+        }
+
+
+def main():
+    """Main event loop for the MCP server."""
+    # Log to stderr so it doesn't interfere with JSON-RPC on stdout
+    print("MCP Calculator Server started", file=sys.stderr)
+    
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        
+        try:
+            request = json.loads(line)
+            method = request.get("method")
+            request_id = request.get("id", 1)
+            params = request.get("params", {})
+            
+            # Handle different MCP methods
+            if method == "tools/list":
+                response = handle_tools_list(request_id)
+            elif method == "tools/call":
+                response = handle_tools_call(request_id, params)
+            else:
+                response = {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "error": {
+                        "code": -32601,
+                        "message": f"Method not found: {method}"
+                    }
+                }
+            
+            # Send response to stdout
+            print(json.dumps(response), flush=True)
+            
+        except json.JSONDecodeError as e:
+            error_response = {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {
+                    "code": -32700,
+                    "message": f"Parse error: {e}"
+                }
+            }
+            print(json.dumps(error_response), flush=True)
+        except Exception as e:
+            error_response = {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {
+                    "code": -32603,
+                    "message": f"Internal error: {e}"
+                }
+            }
+            print(json.dumps(error_response), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/providers/mcp/mod.rs
+++ b/src/providers/mcp/mod.rs
@@ -8,9 +8,18 @@ use crate::providers::base::{BaseProvider, Provider, ProviderType};
 pub struct McpProvider {
     #[serde(flatten)]
     pub base: BaseProvider,
-    pub url: String,
+    // HTTP transport fields
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub headers: Option<HashMap<String, String>>,
+    // Stdio transport fields
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub args: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env_vars: Option<HashMap<String, String>>,
 }
 
 impl Provider for McpProvider {
@@ -28,6 +37,7 @@ impl Provider for McpProvider {
 }
 
 impl McpProvider {
+    // Create HTTP-based MCP provider
     pub fn new(name: String, url: String, auth: Option<AuthConfig>) -> Self {
         Self {
             base: BaseProvider {
@@ -35,8 +45,40 @@ impl McpProvider {
                 provider_type: ProviderType::Mcp,
                 auth,
             },
-            url,
+            url: Some(url),
             headers: None,
+            command: None,
+            args: None,
+            env_vars: None,
         }
+    }
+
+    // Create stdio-based MCP provider
+    pub fn new_stdio(
+        name: String,
+        command: String,
+        args: Option<Vec<String>>,
+        env_vars: Option<HashMap<String, String>>,
+    ) -> Self {
+        Self {
+            base: BaseProvider {
+                name,
+                provider_type: ProviderType::Mcp,
+                auth: None,
+            },
+            url: None,
+            headers: None,
+            command: Some(command),
+            args,
+            env_vars,
+        }
+    }
+
+    pub fn is_stdio(&self) -> bool {
+        self.command.is_some()
+    }
+
+    pub fn is_http(&self) -> bool {
+        self.url.is_some()
     }
 }

--- a/src/transports/mcp/mod.rs
+++ b/src/transports/mcp/mod.rs
@@ -4,6 +4,10 @@ use async_trait::async_trait;
 use reqwest::{header, Client};
 use serde_json::Value;
 use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::sync::Mutex;
 
 use crate::auth::AuthConfig;
 use crate::providers::base::Provider;
@@ -11,14 +15,113 @@ use crate::providers::mcp::McpProvider;
 use crate::tools::Tool;
 use crate::transports::{stream::StreamResult, ClientTransport};
 
+// Stdio process wrapper for MCP transport
+struct McpStdioProcess {
+    #[allow(dead_code)] // Needed to keep the process alive
+    child: Child,
+    stdin: Arc<Mutex<ChildStdin>>,
+    stdout: Arc<Mutex<BufReader<ChildStdout>>>,
+    request_id: Arc<Mutex<u64>>,
+}
+
+impl McpStdioProcess {
+    async fn new(
+        command: &str,
+        args: &Option<Vec<String>>,
+        env_vars: &Option<HashMap<String, String>>,
+    ) -> Result<Self> {
+        let mut cmd = Command::new(command);
+
+        if let Some(args_vec) = args {
+            cmd.args(args_vec);
+        }
+
+        if let Some(env) = env_vars {
+            for (k, v) in env {
+                cmd.env(k, v);
+            }
+        }
+
+        cmd.stdin(std::process::Stdio::piped());
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+
+        let mut child = cmd.spawn()?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow!("Failed to get stdin"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow!("Failed to get stdout"))?;
+
+        Ok(Self {
+            child,
+            stdin: Arc::new(Mutex::new(stdin)),
+            stdout: Arc::new(Mutex::new(BufReader::new(stdout))),
+            request_id: Arc::new(Mutex::new(1)),
+        })
+    }
+
+    async fn send_request(&self, method: &str, params: Value) -> Result<Value> {
+        let mut id_guard = self.request_id.lock().await;
+        let id = *id_guard;
+        *id_guard += 1;
+        drop(id_guard);
+
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+            "id": id,
+        });
+
+        let request_str = serde_json::to_string(&request)?;
+        
+        // Write request to stdin
+        let mut stdin = self.stdin.lock().await;
+        stdin.write_all(request_str.as_bytes()).await?;
+        stdin.write_all(b"\n").await?;
+        stdin.flush().await?;
+        drop(stdin);
+
+        // Read response from stdout
+        let mut stdout = self.stdout.lock().await;
+        let mut line = String::new();
+        stdout.read_line(&mut line).await?;
+        drop(stdout);
+
+        if line.is_empty() {
+            return Err(anyhow!("MCP process closed connection"));
+        }
+
+        let response: Value = serde_json::from_str(&line)?;
+
+        // Check for JSON-RPC error
+        if let Some(error) = response.get("error") {
+            return Err(anyhow!("MCP error: {}", error));
+        }
+
+        response
+            .get("result")
+            .cloned()
+            .ok_or_else(|| anyhow!("No result in MCP response"))
+    }
+}
+
 pub struct McpTransport {
     client: Client,
+    // Map of provider name to stdio process
+    stdio_processes: Arc<Mutex<HashMap<String, Arc<McpStdioProcess>>>>,
 }
 
 impl McpTransport {
     pub fn new() -> Self {
         Self {
             client: Client::new(),
+            stdio_processes: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -51,7 +154,12 @@ impl McpTransport {
         }
     }
 
-    async fn mcp_request(&self, prov: &McpProvider, method: &str, params: Value) -> Result<Value> {
+    async fn mcp_http_request(&self, prov: &McpProvider, method: &str, params: Value) -> Result<Value> {
+        let url = prov
+            .url
+            .as_ref()
+            .ok_or_else(|| anyhow!("No URL provided for HTTP MCP provider"))?;
+
         let request = serde_json::json!({
             "jsonrpc": "2.0",
             "method": method,
@@ -59,7 +167,7 @@ impl McpTransport {
             "id": 1,
         });
 
-        let mut req = self.client.post(&prov.url).json(&request);
+        let mut req = self.client.post(url).json(&request);
         if let Some(headers) = &prov.headers {
             for (k, v) in headers {
                 req = req.header(k, v);
@@ -86,6 +194,40 @@ impl McpTransport {
             .get("result")
             .cloned()
             .ok_or_else(|| anyhow!("No result in MCP response"))
+    }
+
+    async fn get_or_create_stdio_process(
+        &self,
+        prov: &McpProvider,
+    ) -> Result<Arc<McpStdioProcess>> {
+        let mut processes = self.stdio_processes.lock().await;
+        
+        if let Some(process) = processes.get(&prov.base.name) {
+            return Ok(Arc::clone(process));
+        }
+
+        let command = prov
+            .command
+            .as_ref()
+            .ok_or_else(|| anyhow!("No command provided for stdio MCP provider"))?;
+
+        let process = Arc::new(McpStdioProcess::new(command, &prov.args, &prov.env_vars).await?);
+        processes.insert(prov.base.name.clone(), Arc::clone(&process));
+        
+        Ok(process)
+    }
+
+    async fn mcp_request(&self, prov: &McpProvider, method: &str, params: Value) -> Result<Value> {
+        if prov.is_http() {
+            self.mcp_http_request(prov, method, params).await
+        } else if prov.is_stdio() {
+            let process = self.get_or_create_stdio_process(prov).await?;
+            process.send_request(method, params).await
+        } else {
+            Err(anyhow!(
+                "MCP provider must have either 'url' (HTTP) or 'command' (stdio)"
+            ))
+        }
     }
 }
 
@@ -114,6 +256,20 @@ impl ClientTransport for McpTransport {
     }
 
     async fn deregister_tool_provider(&self, _prov: &dyn Provider) -> Result<()> {
+        let mcp_prov = _prov
+            .as_any()
+            .downcast_ref::<McpProvider>()
+            .ok_or_else(|| anyhow!("Provider is not an McpProvider"))?;
+
+        // For stdio processes, terminate the process
+        if mcp_prov.is_stdio() {
+            let mut processes = self.stdio_processes.lock().await;
+            if let Some(process) = processes.remove(&mcp_prov.base.name) {
+                // Process will be dropped and killed when Arc count reaches 0
+                drop(process);
+            }
+        }
+
         Ok(())
     }
 
@@ -148,3 +304,4 @@ impl ClientTransport for McpTransport {
         Err(anyhow!("MCP streaming requires SSE or WebSocket transport"))
     }
 }
+


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add stdio support to the MCP transport so clients can talk to local MCP servers over stdin/stdout. Includes a Python calculator server and a Rust example to demo listing and calling tools.

- New Features
  - MCP stdio transport: spawns a child process, sends JSON-RPC over stdin/stdout, and manages per-provider processes with clean shutdown on deregister.
  - McpProvider now supports both HTTP and stdio (url is optional; new fields: command, args, env_vars). Added helpers: new_stdio, is_stdio, is_http.
  - Added examples: examples/mcp_stdio.rs and examples/mcp_stdio_server.py (tools: add, subtract, multiply, divide). README includes a new run command.
  - HTTP behavior is unchanged; stdio is used only when command is set.

<sup>Written for commit acb0df17bed5f4d804ae09d186e2b0abe20e1674. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

