### PR TITLE
feat: refactor transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1]
+
+### Added
+- Call template handler registry so plugins can register new `call_template_type` converters
+- Global communication protocol registry (`register_communication_protocol`) for pluggable protocols
+
+### Changed
+- Transports renamed to communication protocols throughout the client API while keeping backward compatibility
+- Documentation refreshed to describe the new registries and plugin extension points
+- Dependency update: added `once_cell` for global registry initialization
+
 ## [0.1.8] - 2025-11-26
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1961,7 +1961,7 @@ dependencies = [
 
 [[package]]
 name = "rs-utcp"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1972,6 +1972,7 @@ dependencies = [
  "futures",
  "futures-util",
  "hyper",
+ "once_cell",
  "pin-project",
  "prost",
  "prost-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs-utcp"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Rust implementation of the Universal Tool Calling Protocol (UTCP)."
 license = "MIT OR Apache-2.0"
@@ -18,6 +18,7 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 async-trait = "0.1"
 anyhow = "1.0"
+once_cell = "1.19"
 
 thiserror = "1.0"
 reqwest = { version = "0.11", features = ["json", "stream", "gzip", "deflate", "brotli"] }

--- a/src/call_templates.rs
+++ b/src/call_templates.rs
@@ -1,0 +1,128 @@
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use anyhow::{anyhow, Result};
+use once_cell::sync::Lazy;
+use serde_json::{Map, Value};
+
+/// Function that converts a call template value into a provider value.
+pub type CallTemplateHandler = fn(Value) -> Result<Value>;
+
+/// Global registry of call template handlers keyed by call_template_type.
+pub static CALL_TEMPLATE_HANDLERS: Lazy<RwLock<HashMap<String, CallTemplateHandler>>> =
+    Lazy::new(|| {
+        let mut handlers: HashMap<String, CallTemplateHandler> = HashMap::new();
+        handlers.insert("http".to_string(), http_call_template_handler);
+        handlers.insert("cli".to_string(), cli_call_template_handler);
+        RwLock::new(handlers)
+    });
+
+/// Register or override a call template handler for a call_template_type.
+pub fn register_call_template_handler(key: &str, handler: CallTemplateHandler) {
+    let mut handlers = CALL_TEMPLATE_HANDLERS
+        .write()
+        .expect("call template handler registry poisoned");
+    handlers.insert(key.to_string(), handler);
+}
+
+/// Convert a call template into a provider representation using registered handlers.
+pub fn call_template_to_provider(template: Value) -> Result<Value> {
+    let call_template_type = template
+        .as_object()
+        .and_then(|obj| obj.get("call_template_type"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("Missing call_template_type"))?
+        .to_string();
+
+    let handler = {
+        let handlers = CALL_TEMPLATE_HANDLERS
+            .read()
+            .expect("call template handler registry poisoned");
+        handlers.get(&call_template_type).copied()
+    }
+    .unwrap_or(default_call_template_handler);
+
+    handler(template)
+}
+
+fn normalize_common_template(mut template: Value) -> Result<(String, Map<String, Value>)> {
+    let mut obj = template
+        .as_object_mut()
+        .ok_or_else(|| anyhow!("call template must be an object"))?
+        .clone();
+
+    let ctype = obj
+        .get("call_template_type")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("Missing call_template_type"))?
+        .to_string();
+
+    let name = obj
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or(&ctype)
+        .to_string();
+    obj.entry("name").or_insert(Value::String(name.clone()));
+
+    obj.insert("provider_type".to_string(), Value::String(ctype.clone()));
+    obj.insert("type".to_string(), Value::String(ctype.clone()));
+
+    Ok((ctype, obj))
+}
+
+fn default_call_template_handler(template: Value) -> Result<Value> {
+    let (_, obj) = normalize_common_template(template)?;
+    Ok(Value::Object(obj))
+}
+
+fn http_call_template_handler(template: Value) -> Result<Value> {
+    let (_, mut obj) = normalize_common_template(template)?;
+
+    if let Some(method) = obj.remove("method").or_else(|| obj.remove("http_method")) {
+        obj.insert("http_method".to_string(), method);
+    }
+    if !obj.contains_key("http_method") {
+        obj.insert("http_method".to_string(), Value::String("GET".to_string()));
+    }
+    if let Some(body_field) = obj.remove("body_field") {
+        obj.insert("body_field".to_string(), body_field);
+    }
+    if let Some(headers) = obj.remove("headers") {
+        obj.insert("headers".to_string(), headers);
+    }
+    if let Some(url) = obj.remove("url") {
+        obj.insert("url".to_string(), url);
+    }
+    if !obj.contains_key("url") {
+        obj.insert(
+            "url".to_string(),
+            Value::String("http://localhost".to_string()),
+        );
+    }
+
+    Ok(Value::Object(obj))
+}
+
+fn cli_call_template_handler(template: Value) -> Result<Value> {
+    let (_, mut obj) = normalize_common_template(template)?;
+
+    if let Some(cmd) = obj.remove("command") {
+        obj.insert("command_name".to_string(), cmd);
+    } else if let Some(commands) = obj.get("commands").and_then(|v| v.as_array()) {
+        let first = commands
+            .get(0)
+            .and_then(|c| c.get("command"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("bash -c \"\"");
+        obj.insert("command_name".to_string(), Value::String(first.to_string()));
+    }
+
+    if let Some(env) = obj.remove("env_vars") {
+        obj.insert("env_vars".to_string(), env);
+    }
+    if let Some(cwd) = obj.remove("working_dir") {
+        obj.insert("working_dir".to_string(), cwd);
+    }
+
+    Ok(Value::Object(obj))
+}

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -1,6 +1,8 @@
 use anyhow::{anyhow, Result};
 use serde_json::{json, Map, Value};
 
+use crate::call_templates;
+
 /// Best-effort migration of a v0.1 configuration object to the v1.0 shape.
 /// - providers -> manual_call_templates
 /// - provider_type -> call_template_type
@@ -140,7 +142,7 @@ pub fn provider_to_call_template(provider: &Value) -> Option<Value> {
 
 /// Convert a call template into a provider representation for backward compatibility.
 pub fn call_template_to_provider(template: &Value) -> Option<Value> {
-    provider_to_call_template(template)
+    call_templates::call_template_to_provider(template.clone()).ok()
 }
 
 /// Basic validation for a v1.0 config. Ensures manual_call_templates exist when no providers.

--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -38,3 +38,11 @@ pub trait ClientTransport: Send + Sync {
         prov: &dyn Provider,
     ) -> Result<Box<dyn StreamResult>>;
 }
+
+// CommunicationProtocol is the new name for transports; kept as a re-export for backwards
+// compatibility so plugins can implement the updated terminology without breaking old code.
+pub use ClientTransport as CommunicationProtocol;
+
+pub use registry::{
+    communication_protocols_snapshot, register_communication_protocol, CommunicationProtocolRegistry,
+};

--- a/src/transports/registry.rs
+++ b/src/transports/registry.rs
@@ -1,68 +1,107 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
-use crate::transports::ClientTransport;
+use once_cell::sync::Lazy;
 
-/// Simple plugin-style registry for transports keyed by call_template_type/provider_type.
+use crate::transports::CommunicationProtocol;
+
+/// Plugin-style registry for communication protocols (formerly transports) keyed by call_template_type/provider_type.
 #[derive(Clone, Default)]
-pub struct TransportRegistry {
-    map: HashMap<String, Arc<dyn ClientTransport>>,
+pub struct CommunicationProtocolRegistry {
+    map: HashMap<String, Arc<dyn CommunicationProtocol>>,
 }
 
-impl TransportRegistry {
+impl CommunicationProtocolRegistry {
     pub fn new() -> Self {
         Self {
             map: HashMap::new(),
         }
     }
 
-    pub fn with_default_transports() -> Self {
+    /// Build a registry pre-populated with the built-in communication protocols.
+    pub fn with_default_protocols() -> Self {
         let mut reg = Self::new();
-        reg.register(
-            "http",
-            Arc::new(crate::transports::http::HttpClientTransport::new()),
-        );
-        reg.register("cli", Arc::new(crate::transports::cli::CliTransport::new()));
-        reg.register(
-            "websocket",
-            Arc::new(crate::transports::websocket::WebSocketTransport::new()),
-        );
-        reg.register(
-            "grpc",
-            Arc::new(crate::transports::grpc::GrpcTransport::new()),
-        );
-        reg.register(
-            "graphql",
-            Arc::new(crate::transports::graphql::GraphQLTransport::new()),
-        );
-        reg.register("tcp", Arc::new(crate::transports::tcp::TcpTransport::new()));
-        reg.register("udp", Arc::new(crate::transports::udp::UdpTransport::new()));
-        reg.register("sse", Arc::new(crate::transports::sse::SseTransport::new()));
-        reg.register("mcp", Arc::new(crate::transports::mcp::McpTransport::new()));
-        reg.register(
-            "webrtc",
-            Arc::new(crate::transports::webrtc::WebRtcTransport::new()),
-        );
-        reg.register(
-            "http_stream",
-            Arc::new(crate::transports::http_stream::StreamableHttpTransport::new()),
-        );
-        reg.register(
-            "text",
-            Arc::new(crate::transports::text::TextTransport::new()),
-        );
+        reg.register_default_protocols();
         reg
     }
 
-    pub fn register(&mut self, key: &str, transport: Arc<dyn ClientTransport>) {
-        self.map.insert(key.to_string(), transport);
+    /// Backwards-compatible helper matching the old transport terminology.
+    pub fn with_default_transports() -> Self {
+        Self::with_default_protocols()
     }
 
-    pub fn get(&self, key: &str) -> Option<Arc<dyn ClientTransport>> {
+    pub fn register_default_protocols(&mut self) {
+        self.register(
+            "http",
+            Arc::new(crate::transports::http::HttpClientTransport::new()),
+        );
+        self.register("cli", Arc::new(crate::transports::cli::CliTransport::new()));
+        self.register(
+            "websocket",
+            Arc::new(crate::transports::websocket::WebSocketTransport::new()),
+        );
+        self.register(
+            "grpc",
+            Arc::new(crate::transports::grpc::GrpcTransport::new()),
+        );
+        self.register(
+            "graphql",
+            Arc::new(crate::transports::graphql::GraphQLTransport::new()),
+        );
+        self.register("tcp", Arc::new(crate::transports::tcp::TcpTransport::new()));
+        self.register("udp", Arc::new(crate::transports::udp::UdpTransport::new()));
+        self.register("sse", Arc::new(crate::transports::sse::SseTransport::new()));
+        self.register("mcp", Arc::new(crate::transports::mcp::McpTransport::new()));
+        self.register(
+            "webrtc",
+            Arc::new(crate::transports::webrtc::WebRtcTransport::new()),
+        );
+        self.register(
+            "http_stream",
+            Arc::new(crate::transports::http_stream::StreamableHttpTransport::new()),
+        );
+        self.register(
+            "text",
+            Arc::new(crate::transports::text::TextTransport::new()),
+        );
+    }
+
+    pub fn register(&mut self, key: &str, protocol: Arc<dyn CommunicationProtocol>) {
+        self.map.insert(key.to_string(), protocol);
+    }
+
+    pub fn get(&self, key: &str) -> Option<Arc<dyn CommunicationProtocol>> {
         self.map.get(key).cloned()
     }
 
-    pub fn as_map(&self) -> HashMap<String, Arc<dyn ClientTransport>> {
+    pub fn as_map(&self) -> HashMap<String, Arc<dyn CommunicationProtocol>> {
         self.map.clone()
     }
+}
+
+/// Backwards-compatible alias for the previous registry name.
+pub type TransportRegistry = CommunicationProtocolRegistry;
+
+/// Global, plugin-extensible registry that holds every registered communication protocol.
+pub static GLOBAL_COMMUNICATION_PROTOCOLS: Lazy<RwLock<CommunicationProtocolRegistry>> =
+    Lazy::new(|| {
+        let mut reg = CommunicationProtocolRegistry::new();
+        reg.register_default_protocols();
+        RwLock::new(reg)
+    });
+
+/// Register a new communication protocol (transport) implementation globally so all clients can use it.
+pub fn register_communication_protocol(key: &str, protocol: Arc<dyn CommunicationProtocol>) {
+    let mut reg = GLOBAL_COMMUNICATION_PROTOCOLS
+        .write()
+        .expect("communication protocol registry poisoned");
+    reg.register(key, protocol);
+}
+
+/// Snapshot the current set of registered communication protocols.
+pub fn communication_protocols_snapshot() -> CommunicationProtocolRegistry {
+    GLOBAL_COMMUNICATION_PROTOCOLS
+        .read()
+        .expect("communication protocol registry poisoned")
+        .clone()
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored “transports” into “communication protocols” and introduced global registries for protocols and call template handlers. This makes protocols and call templates pluggable, with full backward compatibility.

- New Features
  - Global communication protocol registry with register_communication_protocol; defaults are pre-registered.
  - Call template handler registry with register_call_template_handler; built-in handlers for http and cli.
  - Back-compat shims: CommunicationProtocol alias for ClientTransport and get_communication_protocols mirrors get_transports.

- Refactors
  - UtcpClient now uses communication_protocols_snapshot and protocol naming throughout.
  - Loader/migration delegate call-template conversion to call_templates::call_template_to_provider (removed duplicate logic).
  - Docs updated to “communication protocols,” added plugin examples; version bumped to 0.2.1; added once_cell.

<sup>Written for commit e0a64bafe33361a68c088e7931c0b64a63aa9bbb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

