### PR TITLE
feat: add docs

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+/// Supported authentication mechanisms across transports.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AuthType {
@@ -9,11 +10,13 @@ pub enum AuthType {
     OAuth2,
 }
 
+/// Contract implemented by auth configs to validate their state and report their type.
 pub trait Auth: Send + Sync + std::fmt::Debug {
     fn auth_type(&self) -> AuthType;
     fn validate(&self) -> Result<(), AuthError>;
 }
 
+/// Validation errors emitted by auth implementations.
 #[derive(Error, Debug)]
 pub enum AuthError {
     #[error("API key must be provided")]
@@ -32,6 +35,7 @@ pub enum AuthError {
     MissingClientSecret,
 }
 
+/// API key authentication descriptor used by HTTP-like transports.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApiKeyAuth {
     pub auth_type: AuthType,
@@ -41,6 +45,7 @@ pub struct ApiKeyAuth {
 }
 
 impl ApiKeyAuth {
+    /// Build an API key auth config with common defaults.
     pub fn new(api_key: String) -> Self {
         Self {
             auth_type: AuthType::ApiKey,
@@ -67,6 +72,7 @@ impl Auth for ApiKeyAuth {
     }
 }
 
+/// Basic authentication descriptor.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BasicAuth {
     pub auth_type: AuthType,
@@ -75,6 +81,7 @@ pub struct BasicAuth {
 }
 
 impl BasicAuth {
+    /// Build a basic auth config from username/password.
     pub fn new(username: String, password: String) -> Self {
         Self {
             auth_type: AuthType::Basic,
@@ -100,6 +107,7 @@ impl Auth for BasicAuth {
     }
 }
 
+/// OAuth2 client credentials descriptor.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OAuth2Auth {
     pub auth_type: AuthType,
@@ -146,6 +154,7 @@ impl Auth for OAuth2Auth {
     }
 }
 
+/// Untagged wrapper that allows serde to deserialize any auth config and still expose the `Auth` trait.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum AuthConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,16 +4,23 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+/// Trait for loading configuration variables from various sources.
 #[async_trait]
 pub trait UtcpVariablesConfig: Send + Sync {
+    /// Loads all variables from the source.
     async fn load(&self) -> Result<HashMap<String, String>>;
+    /// Gets a single variable by key.
     async fn get(&self, key: &str) -> Result<String>;
 }
 
+/// Configuration for the UTCP client, including variables and provider file paths.
 #[derive(Clone)]
 pub struct UtcpClientConfig {
+    /// Map of inline variables.
     pub variables: HashMap<String, String>,
+    /// Path to the providers configuration file.
     pub providers_file_path: Option<PathBuf>,
+    /// List of variable loaders to use.
     pub load_variables_from: Vec<Arc<dyn UtcpVariablesConfig>>,
 }
 
@@ -28,20 +35,24 @@ impl Default for UtcpClientConfig {
 }
 
 impl UtcpClientConfig {
+    /// Creates a new default configuration.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Sets the path to the providers configuration file.
     pub fn with_providers_file(mut self, path: PathBuf) -> Self {
         self.providers_file_path = Some(path);
         self
     }
 
+    /// Adds a single variable to the configuration.
     pub fn with_variable(mut self, key: String, value: String) -> Self {
         self.variables.insert(key, value);
         self
     }
 
+    /// Adds multiple variables to the configuration.
     pub fn with_variables(mut self, vars: HashMap<String, String>) -> Self {
         self.variables.extend(vars);
         self
@@ -53,6 +64,7 @@ impl UtcpClientConfig {
         self
     }
 
+    /// Retrieves a variable value by key, checking inline variables, loaders, and environment variables in order.
     pub async fn get_variable(&self, key: &str) -> Option<String> {
         // Check inline variables first
         if let Some(val) = self.variables.get(key) {
@@ -71,12 +83,13 @@ impl UtcpClientConfig {
     }
 }
 
-// DotEnv variable loader implementation
+/// A variable loader that reads from a .env file.
 pub struct DotEnvLoader {
     file_path: PathBuf,
 }
 
 impl DotEnvLoader {
+    /// Creates a new DotEnvLoader for the specified file path.
     pub fn new(file_path: PathBuf) -> Self {
         Self { file_path }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,15 +1,21 @@
 use thiserror::Error;
 
+/// Represents errors that can occur within the UTCP client.
 #[derive(Error, Debug)]
 pub enum UtcpError {
+    /// Error when a requested tool is not found.
     #[error("Tool not found: {0}")]
     ToolNotFound(String),
+    /// Error related to authentication failures.
     #[error("Authentication failed: {0}")]
     Authentication(String),
+    /// Error occurring during a tool call execution.
     #[error("Tool call failed: {0}")]
     ToolCall(String),
+    /// Error related to invalid configuration.
     #[error("Invalid configuration: {0}")]
     Config(String),
+    /// Other errors wrapped by anyhow.
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -39,9 +39,12 @@ pub async fn load_providers_from_file(
         .collect())
 }
 
-/// Loaded provider plus optional tools (when the input file is a manual).
+/// LoadedProvider represents a provider that has been loaded from a configuration file,
+/// optionally including a list of tools if they were defined in the file (e.g. in a manual).
 pub struct LoadedProvider {
+    /// The loaded provider instance.
     pub provider: Arc<dyn Provider>,
+    /// Optional list of tools associated with this provider.
     pub tools: Option<Vec<crate::tools::Tool>>,
 }
 
@@ -101,6 +104,8 @@ pub async fn load_providers_with_tools_from_file(
     Ok(providers)
 }
 
+/// Parses the raw JSON value into a list of provider JSON objects.
+/// Handles various formats: array, object with "providers", object with "manual_call_templates", or single provider object.
 fn parse_providers_json(json: Value) -> Result<Vec<Value>> {
     match json {
         // Direct array of providers
@@ -161,6 +166,8 @@ fn parse_manual_tools(json: Value) -> Result<Vec<Value>> {
     Ok(providers)
 }
 
+/// Parses a manual JSON object to extract both providers and their associated tools.
+/// Returns a tuple of (providers, tools_per_provider).
 fn parse_manual_tools_with_providers(
     json: Value,
     config: &UtcpClientConfig,
@@ -221,6 +228,8 @@ fn parse_manual_tools_with_providers(
     Ok((providers, tools_per_provider))
 }
 
+/// Extracts a provider definition from a tool JSON object.
+/// Checks for "tool_call_template" or "provider" fields.
 fn tool_to_provider(tool: &Value) -> Result<Option<Value>> {
     let tool_obj = tool
         .as_object()
@@ -239,6 +248,8 @@ fn tool_to_provider(tool: &Value) -> Result<Option<Value>> {
     }
 }
 
+/// Creates a Provider instance from a JSON value.
+/// Handles type normalization and defaults.
 fn create_provider_from_value(mut value: Value, index: usize) -> Result<Arc<dyn Provider>> {
     // Normalize type field: accept both "type" and "provider_type"
     let provider_type = {
@@ -348,6 +359,8 @@ fn create_provider_from_value(mut value: Value, index: usize) -> Result<Arc<dyn 
     }
 }
 
+/// Substitutes variables in the JSON value using the provided configuration.
+/// Replaces ${VAR} and $VAR with values from config or environment.
 fn substitute_variables(value: &mut Value, config: &UtcpClientConfig) {
     match value {
         Value::String(s) => {

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -119,6 +119,8 @@ pub fn migrate_v01_manual(manual: &Value) -> Value {
     Value::Object(out)
 }
 
+/// Converts a provider configuration object into a call template object.
+/// Normalizes fields like `provider_type` to `call_template_type` and ensures HTTP method presence.
 pub fn provider_to_call_template(provider: &Value) -> Option<Value> {
     let mut obj = provider.as_object()?.clone();
     let ptype = obj

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -10,12 +10,14 @@ use crate::tools::{Tool, ToolInputOutputSchema};
 
 pub const VERSION: &str = "1.0";
 
+/// Representation of a generated UTCP manual derived from an OpenAPI spec.
 #[derive(Debug, Clone)]
 pub struct UtcpManual {
     pub version: String,
     pub tools: Vec<Tool>,
 }
 
+/// Converts OpenAPI v2/v3 documents into UTCP tool definitions.
 pub struct OpenApiConverter {
     spec: Value,
     spec_url: Option<String>,
@@ -23,6 +25,7 @@ pub struct OpenApiConverter {
 }
 
 impl OpenApiConverter {
+    /// Build a converter from an already loaded spec value.
     pub fn new(
         openapi_spec: Value,
         spec_url: Option<String>,
@@ -39,11 +42,13 @@ impl OpenApiConverter {
         }
     }
 
+    /// Fetch and parse a remote OpenAPI document, inferring a provider name when missing.
     pub async fn new_from_url(spec_url: &str, provider_name: Option<String>) -> Result<Self> {
         let (spec, final_url) = load_spec_from_url(spec_url).await?;
         Ok(Self::new(spec, Some(final_url), provider_name))
     }
 
+    /// Convert the OpenAPI document into a UTCP manual containing tools and metadata.
     pub fn convert(&self) -> UtcpManual {
         let mut tools = Vec::new();
         let base_url = self.base_url();
@@ -621,6 +626,7 @@ impl OpenApiConverter {
     }
 }
 
+/// Load an OpenAPI/Swagger document from a URL, handling JSON or YAML.
 pub async fn load_spec_from_url(raw_url: &str) -> Result<(Value, String)> {
     let resp = reqwest::get(raw_url).await?;
     let status = resp.status();

--- a/src/providers/base/mod.rs
+++ b/src/providers/base/mod.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::auth::AuthConfig;
 
+/// Provider categories supported by UTCP transports.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ProviderType {
@@ -22,6 +23,7 @@ pub enum ProviderType {
 }
 
 impl ProviderType {
+    /// Transport registry key used to look up the matching communication protocol.
     pub fn as_key(&self) -> &'static str {
         match self {
             ProviderType::Http => "http",
@@ -63,13 +65,18 @@ mod tests {
     }
 }
 
+/// Common interface each provider implementation must expose.
 pub trait Provider: Send + Sync + std::fmt::Debug + std::any::Any {
+    /// Return the provider type used to pick the right transport.
     fn type_(&self) -> ProviderType;
+    /// Human readable provider name used for discovery and namespacing tools.
     fn name(&self) -> String;
 
+    /// Downcast helper for transports that need the concrete provider type.
     fn as_any(&self) -> &dyn std::any::Any;
 }
 
+/// Minimal provider shape shared by most transport-specific provider structs.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BaseProvider {
     pub name: String,

--- a/src/providers/cli/mod.rs
+++ b/src/providers/cli/mod.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use crate::auth::AuthConfig;
 use crate::providers::base::{BaseProvider, Provider, ProviderType};
 
+/// Provider definition for CLI-based tool execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CliProvider {
     #[serde(flatten)]
@@ -30,6 +31,7 @@ impl Provider for CliProvider {
 }
 
 impl CliProvider {
+    /// Construct a CLI provider with a base command and optional authentication metadata.
     pub fn new(name: String, command_name: String, auth: Option<AuthConfig>) -> Self {
         Self {
             base: BaseProvider {

--- a/src/providers/graphql/mod.rs
+++ b/src/providers/graphql/mod.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use crate::auth::AuthConfig;
 use crate::providers::base::{BaseProvider, Provider, ProviderType};
 
+/// Provider configuration for GraphQL endpoints.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GraphqlProvider {
     #[serde(flatten)]
@@ -32,6 +33,7 @@ impl Provider for GraphqlProvider {
 }
 
 impl GraphqlProvider {
+    /// Create a GraphQL provider with sensible defaults.
     pub fn new(name: String, url: String, auth: Option<AuthConfig>) -> Self {
         Self {
             base: BaseProvider {

--- a/src/providers/grpc/mod.rs
+++ b/src/providers/grpc/mod.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::auth::AuthConfig;
 use crate::providers::base::{BaseProvider, Provider, ProviderType};
 
+/// Provider definition for gRPC services.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GrpcProvider {
     #[serde(flatten)]
@@ -28,6 +29,7 @@ impl Provider for GrpcProvider {
 }
 
 impl GrpcProvider {
+    /// Construct a gRPC provider with host/port and optional auth.
     pub fn new(name: String, host: String, port: u16, auth: Option<AuthConfig>) -> Self {
         Self {
             base: BaseProvider {

--- a/src/providers/http/mod.rs
+++ b/src/providers/http/mod.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use crate::auth::AuthConfig;
 use crate::providers::base::{BaseProvider, Provider, ProviderType};
 
+/// Provider configuration for HTTP-based tools.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HttpProvider {
     #[serde(flatten)]
@@ -35,6 +36,7 @@ impl Provider for HttpProvider {
 }
 
 impl HttpProvider {
+    /// Create an HTTP provider with common defaults (JSON content type and GET/POST URLs).
     pub fn new(name: String, url: String, http_method: String, auth: Option<AuthConfig>) -> Self {
         Self {
             base: BaseProvider {

--- a/src/providers/http_stream/mod.rs
+++ b/src/providers/http_stream/mod.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use crate::auth::AuthConfig;
 use crate::providers::base::{BaseProvider, Provider, ProviderType};
 
+/// Provider definition for streaming HTTP endpoints that emit chunked JSON.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StreamableHttpProvider {
     #[serde(flatten)]
@@ -30,6 +31,7 @@ impl Provider for StreamableHttpProvider {
 }
 
 impl StreamableHttpProvider {
+    /// Construct a streaming HTTP provider pointing at a base URL.
     pub fn new(name: String, url: String, auth: Option<AuthConfig>) -> Self {
         Self {
             base: BaseProvider {

--- a/src/providers/mcp/mod.rs
+++ b/src/providers/mcp/mod.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use crate::auth::AuthConfig;
 use crate::providers::base::{BaseProvider, Provider, ProviderType};
 
+/// Provider definition for MCP servers reachable over HTTP or stdio.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpProvider {
     #[serde(flatten)]
@@ -37,7 +38,7 @@ impl Provider for McpProvider {
 }
 
 impl McpProvider {
-    // Create HTTP-based MCP provider
+    /// Create an HTTP-based MCP provider.
     pub fn new(name: String, url: String, auth: Option<AuthConfig>) -> Self {
         Self {
             base: BaseProvider {
@@ -53,7 +54,7 @@ impl McpProvider {
         }
     }
 
-    // Create stdio-based MCP provider
+    /// Create a stdio-based MCP provider that spawns a local process.
     pub fn new_stdio(
         name: String,
         command: String,
@@ -74,10 +75,12 @@ impl McpProvider {
         }
     }
 
+    /// True if the provider should be reached via stdio.
     pub fn is_stdio(&self) -> bool {
         self.command.is_some()
     }
 
+    /// True if the provider should be reached via HTTP.
     pub fn is_http(&self) -> bool {
         self.url.is_some()
     }

--- a/src/providers/sse/mod.rs
+++ b/src/providers/sse/mod.rs
@@ -33,6 +33,7 @@ impl Provider for SseProvider {
 }
 
 impl SseProvider {
+    /// Construct an SSE provider pointing at a streaming endpoint.
     pub fn new(name: String, url: String, auth: Option<AuthConfig>) -> Self {
         Self {
             base: BaseProvider {

--- a/src/providers/tcp/mod.rs
+++ b/src/providers/tcp/mod.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::auth::AuthConfig;
 use crate::providers::base::{BaseProvider, Provider, ProviderType};
 
+/// Provider definition for plain TCP endpoints.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TcpProvider {
     #[serde(flatten)]
@@ -28,6 +29,7 @@ impl Provider for TcpProvider {
 }
 
 impl TcpProvider {
+    /// Create a TCP provider with host/port and optional timeout.
     pub fn new(name: String, host: String, port: u16, auth: Option<AuthConfig>) -> Self {
         Self {
             base: BaseProvider {

--- a/src/providers/text/mod.rs
+++ b/src/providers/text/mod.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use crate::auth::AuthConfig;
 use crate::providers::base::{BaseProvider, Provider, ProviderType};
 
+/// Provider definition for file-backed text tools.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TextProvider {
     #[serde(flatten)]
@@ -27,6 +28,7 @@ impl Provider for TextProvider {
 }
 
 impl TextProvider {
+    /// Create a text provider with an optional base directory for scripts and manifests.
     pub fn new(name: String, base_path: Option<PathBuf>, auth: Option<AuthConfig>) -> Self {
         Self {
             base: BaseProvider {

--- a/src/providers/udp/mod.rs
+++ b/src/providers/udp/mod.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::auth::AuthConfig;
 use crate::providers::base::{BaseProvider, Provider, ProviderType};
 
+/// Provider definition for UDP datagram endpoints.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UdpProvider {
     #[serde(flatten)]
@@ -28,6 +29,7 @@ impl Provider for UdpProvider {
 }
 
 impl UdpProvider {
+    /// Create a UDP provider with host/port and optional timeout.
     pub fn new(name: String, host: String, port: u16, auth: Option<AuthConfig>) -> Self {
         Self {
             base: BaseProvider {

--- a/src/providers/webrtc/mod.rs
+++ b/src/providers/webrtc/mod.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::auth::AuthConfig;
 use crate::providers::base::{BaseProvider, Provider, ProviderType};
 
+/// STUN/TURN server configuration passed to the WebRTC stack.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IceServer {
     pub urls: Vec<String>,
@@ -12,6 +13,7 @@ pub struct IceServer {
     pub credential: Option<String>,
 }
 
+/// Provider definition for peer-to-peer WebRTC transports.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WebRtcProvider {
     #[serde(flatten)]
@@ -72,6 +74,7 @@ impl Provider for WebRtcProvider {
 }
 
 impl WebRtcProvider {
+    /// Construct a WebRTC provider backed by a signaling server URL.
     pub fn new(name: String, signaling_server: String, auth: Option<AuthConfig>) -> Self {
         Self {
             base: BaseProvider {

--- a/src/providers/websocket/mod.rs
+++ b/src/providers/websocket/mod.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use crate::auth::AuthConfig;
 use crate::providers::base::{BaseProvider, Provider, ProviderType};
 
+/// Provider configuration for WebSocket endpoints.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WebSocketProvider {
     #[serde(flatten)]
@@ -32,6 +33,7 @@ impl Provider for WebSocketProvider {
 }
 
 impl WebSocketProvider {
+    /// Create a WebSocket provider pointing at a URL.
     pub fn new(name: String, url: String, auth: Option<AuthConfig>) -> Self {
         Self {
             base: BaseProvider {

--- a/src/repository/in_memory.rs
+++ b/src/repository/in_memory.rs
@@ -7,12 +7,14 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+/// Simple in-memory repository for tests and local usage.
 pub struct InMemoryToolRepository {
     tools: RwLock<HashMap<String, Vec<Tool>>>, // provider_name -> tools
     providers: RwLock<HashMap<String, Arc<dyn Provider>>>, // provider_name -> Provider
 }
 
 impl InMemoryToolRepository {
+    /// Create an empty repository instance.
     pub fn new() -> Self {
         Self {
             tools: RwLock::new(HashMap::new()),

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -6,15 +6,21 @@ use anyhow::Result;
 use async_trait::async_trait;
 use std::sync::Arc;
 
+/// Persistence abstraction for storing providers and their tools.
 #[async_trait]
 pub trait ToolRepository: Send + Sync {
+    /// Save a provider along with the full list of tools it offers.
     async fn save_provider_with_tools(
         &self,
         prov: Arc<dyn Provider>,
         tools: Vec<Tool>,
     ) -> Result<()>;
+    /// Retrieve a provider by name if it exists.
     async fn get_provider(&self, name: &str) -> Result<Option<Arc<dyn Provider>>>;
+    /// Remove a provider and its tools.
     async fn remove_provider(&self, name: &str) -> Result<()>;
+    /// Return all registered tools across all providers.
     async fn get_tools(&self) -> Result<Vec<Tool>>;
+    /// Return tools offered by a specific provider.
     async fn get_tools_by_provider(&self, provider_name: &str) -> Result<Vec<Tool>>;
 }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -4,56 +4,84 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct CallTemplate {
+    /// The type of the call template (e.g., "http", "cli").
     pub call_template_type: String,
+    /// Optional name for the template.
     #[serde(default)]
     pub name: Option<String>,
+    /// URL for HTTP-based templates.
     #[serde(default)]
     pub url: Option<String>,
+    /// HTTP method for HTTP-based templates.
     #[serde(default)]
     pub http_method: Option<String>,
+    /// Command string for CLI-based templates.
     #[serde(default)]
     pub command: Option<String>,
+    /// List of commands for multi-step CLI templates.
     #[serde(default)]
     pub commands: Option<Vec<TemplateCommand>>,
+    /// Environment variables to set for the command.
     #[serde(default)]
     pub env_vars: Option<std::collections::HashMap<String, String>>,
+    /// Working directory for the command.
     #[serde(default)]
     pub working_dir: Option<String>,
 }
 
+/// Represents a single command in a multi-step CLI template.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TemplateCommand {
+    /// The command string to execute.
     pub command: String,
+    /// Whether to append the output of this command to the final result.
     #[serde(default)]
     pub append_to_final_output: Option<bool>,
 }
 
+/// Metadata information about a manual.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ManualInfo {
+    /// Title of the manual.
     pub title: String,
+    /// Version of the manual.
     pub version: String,
     #[serde(default)]
+    /// Optional description of the manual.
     pub description: Option<String>,
 }
 
+/// Represents a tool definition within a manual.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ManualTool {
+    /// Name of the tool.
     pub name: String,
+    /// Description of what the tool does.
     pub description: String,
+    /// JSON schema for the tool's inputs.
     pub inputs: serde_json::Value,
+    /// JSON schema for the tool's outputs.
     pub outputs: serde_json::Value,
+    /// Tags associated with the tool.
     #[serde(default)]
     pub tags: Vec<String>,
+    /// The call template defining how to execute the tool.
     #[serde(default)]
     pub tool_call_template: Option<CallTemplate>,
+    /// Legacy provider definition (deprecated).
     #[serde(default)]
     pub provider: Option<CallTemplate>, // legacy in-tool provider
 }
 
+/// Represents a v1.0 Manual structure containing tool definitions and metadata.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ManualV1 {
+    /// Version of the manual format.
     pub manual_version: String,
+    /// Version of the UTCP protocol.
     pub utcp_version: String,
+    /// Metadata about the manual.
     pub info: ManualInfo,
+    /// List of tools defined in the manual.
     pub tools: Vec<ManualTool>,
 }

--- a/src/tag/tag_search.rs
+++ b/src/tag/tag_search.rs
@@ -6,6 +6,7 @@ use regex::Regex;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+/// Simple tag/description based search that rewards tag matches and keyword overlap.
 pub struct TagSearchStrategy {
     tool_repository: Arc<dyn ToolRepository>,
     description_weight: f64,
@@ -13,6 +14,7 @@ pub struct TagSearchStrategy {
 }
 
 impl TagSearchStrategy {
+    /// Build a new tag search strategy with configurable description weight.
     pub fn new(repo: Arc<dyn ToolRepository>, description_weight: f64) -> Self {
         Self {
             tool_repository: repo,
@@ -29,6 +31,7 @@ struct ScoredTool {
 
 #[async_trait]
 impl ToolSearchStrategy for TagSearchStrategy {
+    /// Score tools by tags and description keywords and return the best matches.
     async fn search_tools(&self, query: &str, limit: usize) -> Result<Vec<Tool>> {
         let query_lower = query.trim().to_lowercase();
         let words: Vec<String> = self

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Minimal JSON Schema-like description for tool inputs/outputs.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolInputOutputSchema {
     #[serde(rename = "type")]
@@ -27,6 +28,7 @@ pub struct ToolInputOutputSchema {
     pub format: Option<String>,
 }
 
+/// Canonical tool definition used by UTCP transports and repositories.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Tool {
     pub name: String,
@@ -40,7 +42,9 @@ pub struct Tool {
     pub provider: Option<serde_json::Value>,
 }
 
+/// Strategy abstraction used to search tools by query string.
 #[async_trait]
 pub trait ToolSearchStrategy: Send + Sync {
+    /// Return tools matching the query string, limited to `limit` results when non-zero.
     async fn search_tools(&self, query: &str, limit: usize) -> Result<Vec<Tool>>;
 }

--- a/src/transports/cli/mod.rs
+++ b/src/transports/cli/mod.rs
@@ -12,9 +12,11 @@ use crate::providers::cli::CliProvider;
 use crate::tools::Tool;
 use crate::transports::{stream::StreamResult, ClientTransport};
 
+/// Transport that shells out to a CLI binary which exposes UTCP-compatible commands.
 pub struct CliTransport;
 
 impl CliTransport {
+    /// Create a CLI transport.
     pub fn new() -> Self {
         Self
     }

--- a/src/transports/graphql/mod.rs
+++ b/src/transports/graphql/mod.rs
@@ -11,11 +11,13 @@ use crate::providers::graphql::GraphqlProvider;
 use crate::tools::{Tool, ToolInputOutputSchema};
 use crate::transports::{stream::StreamResult, ClientTransport};
 
+/// Transport that maps GraphQL operations to UTCP tools.
 pub struct GraphQLTransport {
     client: Client,
 }
 
 impl GraphQLTransport {
+    /// Create a GraphQL transport using a default reqwest client.
     pub fn new() -> Self {
         Self {
             client: Client::new(),

--- a/src/transports/grpc/mod.rs
+++ b/src/transports/grpc/mod.rs
@@ -22,9 +22,11 @@ use crate::transports::{
 use crate::grpcpb::generated::utcp_service_client::UtcpServiceClient;
 use crate::grpcpb::generated::{Empty, ToolCallRequest};
 
+/// Transport implementation that communicates with UTCP servers over gRPC.
 pub struct GrpcTransport;
 
 impl GrpcTransport {
+    /// Create a gRPC transport instance.
     pub fn new() -> Self {
         Self
     }

--- a/src/transports/http/mod.rs
+++ b/src/transports/http/mod.rs
@@ -11,11 +11,13 @@ use crate::providers::http::HttpProvider;
 use crate::tools::Tool;
 use crate::transports::{stream::StreamResult, ClientTransport};
 
+/// Transport for synchronous HTTP providers that expose JSON APIs.
 pub struct HttpClientTransport {
     pub client: Client,
 }
 
 impl HttpClientTransport {
+    /// Build a new HTTP client transport with tuned defaults.
     pub fn new() -> Self {
         // Optimized HTTP client with connection pooling and compression
         let client = Client::builder()
@@ -34,6 +36,7 @@ impl HttpClientTransport {
         Self { client }
     }
 
+    /// Attach authentication headers or query params to the request builder.
     fn apply_auth(
         &self,
         builder: reqwest::RequestBuilder,

--- a/src/transports/http_stream/mod.rs
+++ b/src/transports/http_stream/mod.rs
@@ -16,17 +16,20 @@ use crate::transports::{
     ClientTransport,
 };
 
+/// Transport for HTTP endpoints that stream newline-delimited JSON or chunked bodies.
 pub struct StreamableHttpTransport {
     client: Client,
 }
 
 impl StreamableHttpTransport {
+    /// Create a streaming HTTP transport with a default client.
     pub fn new() -> Self {
         Self {
             client: Client::new(),
         }
     }
 
+    /// Attach authentication headers or query params to the request builder.
     fn apply_auth(
         &self,
         builder: reqwest::RequestBuilder,

--- a/src/transports/mcp/mod.rs
+++ b/src/transports/mcp/mod.rs
@@ -114,6 +114,7 @@ impl McpStdioProcess {
     }
 }
 
+/// Transport for MCP providers over HTTP or stdio.
 pub struct McpTransport {
     client: Client,
     // Map of provider name to stdio process
@@ -121,6 +122,7 @@ pub struct McpTransport {
 }
 
 impl McpTransport {
+    /// Create an MCP transport with a tuned reqwest client.
     pub fn new() -> Self {
         // Optimized HTTP client for MCP transport
         let client = Client::builder()

--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -21,16 +21,21 @@ use async_trait::async_trait;
 use serde_json::Value;
 use std::collections::HashMap;
 
+/// Core transport abstraction all communication protocols implement.
 #[async_trait]
 pub trait ClientTransport: Send + Sync {
+    /// Register a tool provider with the underlying transport, returning discovered tools.
     async fn register_tool_provider(&self, prov: &dyn Provider) -> Result<Vec<Tool>>;
+    /// Deregister a tool provider and release any associated resources.
     async fn deregister_tool_provider(&self, prov: &dyn Provider) -> Result<()>;
+    /// Invoke a tool over the transport and return the result payload.
     async fn call_tool(
         &self,
         tool_name: &str,
         args: HashMap<String, Value>,
         prov: &dyn Provider,
     ) -> Result<Value>;
+    /// Invoke a tool and stream incremental responses back to the caller.
     async fn call_tool_stream(
         &self,
         tool_name: &str,

--- a/src/transports/registry.rs
+++ b/src/transports/registry.rs
@@ -12,6 +12,7 @@ pub struct CommunicationProtocolRegistry {
 }
 
 impl CommunicationProtocolRegistry {
+    /// Create an empty registry without any transports.
     pub fn new() -> Self {
         Self {
             map: Arc::new(RwLock::new(HashMap::new())),
@@ -30,6 +31,7 @@ impl CommunicationProtocolRegistry {
         Self::with_default_protocols()
     }
 
+    /// Register all built-in transports into this registry instance.
     pub fn register_default_protocols(&self) {
         self.register(
             "http",
@@ -66,6 +68,7 @@ impl CommunicationProtocolRegistry {
         );
     }
 
+    /// Add a protocol implementation under the provided key.
     pub fn register(&self, key: &str, protocol: Arc<dyn CommunicationProtocol>) {
         let mut guard = self
             .map
@@ -74,6 +77,7 @@ impl CommunicationProtocolRegistry {
         guard.insert(key.to_string(), protocol);
     }
 
+    /// Look up a protocol by key.
     pub fn get(&self, key: &str) -> Option<Arc<dyn CommunicationProtocol>> {
         let guard = self
             .map
@@ -82,6 +86,7 @@ impl CommunicationProtocolRegistry {
         guard.get(key).cloned()
     }
 
+    /// Return a copy of the current map for inspection or iteration.
     pub fn as_map(&self) -> HashMap<String, Arc<dyn CommunicationProtocol>> {
         let guard = self
             .map

--- a/src/transports/sse/mod.rs
+++ b/src/transports/sse/mod.rs
@@ -17,11 +17,13 @@ use crate::transports::{
     ClientTransport,
 };
 
+/// Transport for Server-Sent Events endpoints that return event streams per tool call.
 pub struct SseTransport {
     client: Client,
 }
 
 impl SseTransport {
+    /// Create an SSE transport backed by a reqwest client.
     pub fn new() -> Self {
         Self {
             client: Client::new(),

--- a/src/transports/stream.rs
+++ b/src/transports/stream.rs
@@ -19,6 +19,7 @@ pub struct ChannelStreamResult {
 }
 
 impl ChannelStreamResult {
+    /// Create a new channel-backed stream with an optional close callback.
     pub fn new(
         rx: mpsc::Receiver<Result<Value>>,
         close_fn: Option<Box<dyn FnOnce() -> Result<()> + Send>>,
@@ -53,6 +54,7 @@ pub struct VecStreamResult {
 }
 
 impl VecStreamResult {
+    /// Wrap an eager collection of values as a stream result.
     pub fn new(
         items: Vec<Value>,
         close_fn: Option<Box<dyn FnOnce() -> Result<()> + Send>>,

--- a/src/transports/tcp/mod.rs
+++ b/src/transports/tcp/mod.rs
@@ -16,9 +16,11 @@ use crate::transports::{
     ClientTransport,
 };
 
+/// TCP transport used for simple length-delimited or line-delimited JSON exchanges.
 pub struct TcpTransport;
 
 impl TcpTransport {
+    /// Create a TCP transport instance.
     pub fn new() -> Self {
         Self
     }

--- a/src/transports/text/mod.rs
+++ b/src/transports/text/mod.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use tokio::fs;
 use tokio::process::Command;
 
+/// Transport that loads tools from a directory and executes scripts locally.
 pub struct TextTransport {
     base_path: Option<PathBuf>,
 }
@@ -23,10 +24,12 @@ enum ScriptKind {
 }
 
 impl TextTransport {
+    /// Create a text transport without a default base path.
     pub fn new() -> Self {
         Self { base_path: None }
     }
 
+    /// Configure a base directory that holds tool scripts and manifests.
     pub fn with_base_path(mut self, path: PathBuf) -> Self {
         self.base_path = Some(path);
         self

--- a/src/transports/udp/mod.rs
+++ b/src/transports/udp/mod.rs
@@ -11,9 +11,11 @@ use crate::providers::udp::UdpProvider;
 use crate::tools::Tool;
 use crate::transports::{stream::StreamResult, ClientTransport};
 
+/// Datagram-based transport for lightweight request/response tools.
 pub struct UdpTransport;
 
 impl UdpTransport {
+    /// Create a UDP transport instance.
     pub fn new() -> Self {
         Self
     }

--- a/src/transports/webrtc/mod.rs
+++ b/src/transports/webrtc/mod.rs
@@ -24,12 +24,14 @@ use crate::transports::{
     ClientTransport,
 };
 
+/// Peer-to-peer transport that relays tool calls over WebRTC data channels.
 pub struct WebRtcTransport {
     // Cache of active peer connections
     connections: Arc<Mutex<HashMap<String, Arc<RTCPeerConnection>>>>,
 }
 
 impl WebRtcTransport {
+    /// Create an empty transport with no cached connections.
     pub fn new() -> Self {
         Self {
             connections: Arc::new(Mutex::new(HashMap::new())),

--- a/src/transports/websocket/mod.rs
+++ b/src/transports/websocket/mod.rs
@@ -26,9 +26,11 @@ use crate::transports::{
     ClientTransport,
 };
 
+/// Transport that communicates with tools over WebSocket connections.
 pub struct WebSocketTransport;
 
 impl WebSocketTransport {
+    /// Create a WebSocket transport.
     pub fn new() -> Self {
         Self
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added rustdoc throughout the UTCP client, auth/config, providers, transports, loader/OpenAPI converter, repository, and tool/search modules to generate clear API docs and improve discoverability. No functional changes; documentation-only.

<sup>Written for commit 731cf16df362e975e98cdc9ef04209687866cae4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

