### PR TITLE
feat: optimize search tools

### DIFF
--- a/src/repository/in_memory.rs
+++ b/src/repository/in_memory.rs
@@ -58,7 +58,8 @@ impl ToolRepository for InMemoryToolRepository {
 
     async fn get_tools(&self) -> Result<Vec<Tool>> {
         let tools_map = self.tools.read().await;
-        let mut all_tools = Vec::new();
+        let total_len: usize = tools_map.values().map(|tools| tools.len()).sum();
+        let mut all_tools = Vec::with_capacity(total_len);
         for tools in tools_map.values() {
             all_tools.extend(tools.clone());
         }

--- a/src/tag/tag_search.rs
+++ b/src/tag/tag_search.rs
@@ -3,6 +3,7 @@ use crate::tools::{Tool, ToolSearchStrategy};
 use anyhow::Result;
 use async_trait::async_trait;
 use regex::Regex;
+use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -24,6 +25,7 @@ impl TagSearchStrategy {
     }
 }
 
+#[derive(Clone)]
 struct ScoredTool {
     tool: Tool,
     score: f64,
@@ -34,76 +36,205 @@ impl ToolSearchStrategy for TagSearchStrategy {
     /// Score tools by tags and description keywords and return the best matches.
     async fn search_tools(&self, query: &str, limit: usize) -> Result<Vec<Tool>> {
         let query_lower = query.trim().to_lowercase();
-        let words: Vec<String> = self
+        let query_word_set: HashSet<String> = self
             .word_regex
             .find_iter(&query_lower)
             .map(|m| m.as_str().to_string())
             .collect();
 
-        let query_word_set: HashSet<String> = words.into_iter().collect();
-
         let tools = self.tool_repository.get_tools().await?;
-        let mut scored: Vec<ScoredTool> = Vec::new();
+        if tools.is_empty() {
+            return Ok(Vec::new());
+        }
 
-        for t in tools {
-            let mut score = 0.0;
+        let mut positives = Vec::new();
+        let mut nonpositives = Vec::new();
 
-            // Match against tags
-            for tag in &t.tags {
-                let tag_lower = tag.to_lowercase();
+        for tool in tools {
+            let score = self.score_tool(&tool, &query_lower, &query_word_set);
+            let entry = ScoredTool { tool, score };
+            if score > 0.0 {
+                positives.push(entry);
+            } else {
+                nonpositives.push(entry);
+            }
+        }
 
-                // Direct substring match
-                if query_lower.contains(&tag_lower) {
-                    score += 1.0;
-                }
-
-                // Word-level overlap
-                for m in self.word_regex.find_iter(&tag_lower) {
-                    if query_word_set.contains(m.as_str()) {
-                        score += self.description_weight;
-                    }
-                }
+        // Unbounded result set keeps full sort for correctness but skips zero-score tools unless necessary.
+        if limit == 0 {
+            if !positives.is_empty() {
+                positives.sort_unstable_by(compare_scored);
+                return Ok(positives.into_iter().map(|st| st.tool).collect());
             }
 
-            // Match against description
-            let desc_lower = t.description.to_lowercase();
-            for m in self.word_regex.find_iter(&desc_lower) {
-                let w = m.as_str();
-                if w.len() > 2 && query_word_set.contains(w) {
+            nonpositives.sort_unstable_by(compare_scored);
+            return Ok(nonpositives.into_iter().map(|st| st.tool).collect());
+        }
+
+        if !positives.is_empty() {
+            take_top_n(&mut positives, limit);
+            return Ok(positives.into_iter().map(|st| st.tool).collect());
+        }
+
+        if nonpositives.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        take_top_n(&mut nonpositives, limit);
+        Ok(nonpositives.into_iter().map(|st| st.tool).collect())
+    }
+}
+
+impl TagSearchStrategy {
+    fn score_tool(&self, tool: &Tool, query_lower: &str, query_word_set: &HashSet<String>) -> f64 {
+        let mut score = 0.0;
+
+        for tag in &tool.tags {
+            let tag_lower = tag.to_ascii_lowercase();
+
+            if query_lower.contains(&tag_lower) {
+                score += 1.0;
+            }
+
+            for m in self.word_regex.find_iter(&tag_lower) {
+                if query_word_set.contains(m.as_str()) {
                     score += self.description_weight;
                 }
             }
-
-            scored.push(ScoredTool { tool: t, score });
         }
 
-        // Sort descending by score
-        scored.sort_by(|a, b| {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
+        for m in self.word_regex.find_iter(&tool.description) {
+            let word = m.as_str().to_ascii_lowercase();
+            if word.len() > 2 && query_word_set.contains(&word) {
+                score += self.description_weight;
+            }
+        }
+
+        score
+    }
+}
+
+fn compare_scored(a: &ScoredTool, b: &ScoredTool) -> Ordering {
+    b.score
+        .total_cmp(&a.score)
+        .then_with(|| a.tool.name.cmp(&b.tool.name))
+}
+
+fn take_top_n(scored: &mut Vec<ScoredTool>, limit: usize) {
+    if limit == 0 {
+        scored.sort_unstable_by(compare_scored);
+        return;
+    }
+
+    if scored.len() > limit {
+        let pivot = limit - 1;
+        scored.select_nth_unstable_by(pivot, compare_scored);
+        scored.truncate(limit);
+    }
+
+    scored.sort_unstable_by(compare_scored);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::base::{BaseProvider, ProviderType};
+    use crate::repository::in_memory::InMemoryToolRepository;
+    use crate::tools::ToolInputOutputSchema;
+    use std::sync::Arc;
+
+    fn schema() -> ToolInputOutputSchema {
+        ToolInputOutputSchema {
+            type_: "object".to_string(),
+            properties: None,
+            required: None,
+            description: None,
+            title: None,
+            items: None,
+            enum_: None,
+            minimum: None,
+            maximum: None,
+            format: None,
+        }
+    }
+
+    fn make_tool(name: &str, description: &str, tags: &[&str]) -> Tool {
+        Tool {
+            name: name.to_string(),
+            description: description.to_string(),
+            inputs: schema(),
+            outputs: schema(),
+            tags: tags.iter().map(|t| t.to_string()).collect(),
+            average_response_size: None,
+            provider: None,
+        }
+    }
+
+    async fn setup_repo(tools: Vec<Tool>) -> Arc<InMemoryToolRepository> {
+        let repo = Arc::new(InMemoryToolRepository::new());
+        let provider = Arc::new(BaseProvider {
+            name: "test".to_string(),
+            provider_type: ProviderType::Http,
+            auth: None,
         });
+        repo.save_provider_with_tools(provider, tools)
+            .await
+            .unwrap();
+        repo
+    }
 
-        let mut result = Vec::new();
-        for st in scored.iter() {
-            if st.score > 0.0 {
-                result.push(st.tool.clone());
-                if limit > 0 && result.len() >= limit {
-                    break;
-                }
-            }
-        }
+    #[tokio::test]
+    async fn returns_top_scoring_tools_with_limit() {
+        let repo = setup_repo(vec![
+            make_tool(
+                "p1.weather_primary",
+                "Weather forecast endpoint",
+                &["weather"],
+            ),
+            make_tool("p1.weather_backup", "Weather data service", &["climate"]),
+            make_tool("p1.finance", "Stock price lookup", &["stocks"]),
+        ])
+        .await;
 
-        // If no matches, fallback to top N (for discoverability)
-        if result.is_empty() && !scored.is_empty() {
-            for (i, st) in scored.iter().enumerate() {
-                if limit > 0 && i >= limit {
-                    break;
-                }
-                result.push(st.tool.clone());
-            }
-        }
+        let strategy = TagSearchStrategy::new(repo, 0.5);
+        let results = strategy.search_tools("weather forecast", 2).await.unwrap();
 
-        Ok(result)
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].name, "p1.weather_primary");
+        assert_eq!(results[1].name, "p1.weather_backup");
+    }
+
+    #[tokio::test]
+    async fn falls_back_when_no_positive_scores() {
+        let repo = setup_repo(vec![
+            make_tool("p1.alpha", "No overlap here", &["alpha"]),
+            make_tool("p1.beta", "Still nothing useful", &["beta"]),
+            make_tool("p1.gamma", "More unrelated content", &["gamma"]),
+        ])
+        .await;
+
+        let strategy = TagSearchStrategy::new(repo, 1.0);
+        let results = strategy.search_tools("nonsense", 2).await.unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].name, "p1.alpha");
+        assert_eq!(results[1].name, "p1.beta");
+    }
+
+    #[tokio::test]
+    async fn ties_are_sorted_by_name_within_limit() {
+        let repo = setup_repo(vec![
+            make_tool("p1.alpha", "Math helper", &["math"]),
+            make_tool("p1.beta", "Math helper", &["math"]),
+            make_tool("p1.gamma", "Math helper", &["math"]),
+        ])
+        .await;
+
+        let strategy = TagSearchStrategy::new(repo, 1.0);
+        let results = strategy.search_tools("math", 2).await.unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].name, "p1.alpha");
+        assert_eq!(results[1].name, "p1.beta");
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Optimized tool search for faster performance and deterministic results, with clearer fallback behavior when no positive matches. Also reduced allocations when aggregating tools.

- **Refactors**
  - Uses select_nth_unstable_by for top-N selection instead of full sorting.
  - Deterministic ranking via total_cmp with name tie-breaks.
  - Scores split into positives vs nonpositives; returns positives first, else falls back.
  - Preallocates get_tools capacity and short-circuits on empty sets; added unit tests for ranking, fallback, and tie ordering.

<sup>Written for commit bb5b0ff2c3f60c74a0d16cf327efe15fea27ba73. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

