### PR TITLE
feat: add benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +354,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +397,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +432,31 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "compression-codecs"
@@ -480,6 +550,69 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -923,6 +1056,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,6 +1083,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1224,6 +1374,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,6 +1620,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,6 +1806,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1717,7 +1921,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck",
- "itertools",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -1737,7 +1941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -1795,6 +1999,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1961,13 +2185,14 @@ dependencies = [
 
 [[package]]
 name = "rs-utcp"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",
  "axum",
  "base64 0.21.7",
  "bytes",
+ "criterion",
  "eventsource-stream",
  "futures",
  "futures-util",
@@ -2146,6 +2371,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2642,6 +2876,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2991,6 +3235,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3313,6 +3567,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs-utcp"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 description = "Rust implementation of the Universal Tool Calling Protocol (UTCP)."
 license = "MIT OR Apache-2.0"
@@ -48,3 +48,16 @@ tonic = { version = "0.11", features = ["transport", "tls"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 axum = "0.6"
 uuid = { version = "1", features = ["v4"] }
+criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
+
+[[bench]]
+name = "tool_operations"
+harness = false
+
+[[bench]]
+name = "protocol_comparison"
+harness = false
+
+[[bench]]
+name = "codemode_execution"
+harness = false

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,171 @@
+# Performance Benchmarks
+
+This directory contains comprehensive performance benchmarks for the `rs-utcp` library using [Criterion.rs](https://github.com/bheisler/criterion.rs).
+
+## Benchmark Suites
+
+### 1. Tool Operations (`tool_operations.rs`)
+
+Measures core UTCP client operations:
+
+- **Tool Registration**: Performance with varying numbers of tools (10, 50, 100, 500)
+- **Tool Search**: Search performance across different repository sizes
+- **Client Initialization**: Overhead of creating a new client
+- **Tool Call Overhead**: Impact of different argument counts
+- **Tag Matching**: Performance of the tag-based search algorithm
+
+### 2. Protocol Comparison (`protocol_comparison.rs`)
+
+Compares different communication protocol implementations:
+
+- **Provider Registration**: Overhead for HTTP, CLI, WebSocket, MCP protocols
+- **Serialization**: JSON serialization performance for different provider types
+- **CLI Tool Calls**: Actual execution performance for CLI-based tools
+
+### 3. Codemode Execution (`codemode_execution.rs`)
+
+Benchmarks the Rhai script execution engine:
+
+- **Script Complexity**: Simple arithmetic, loops, arrays, maps
+- **Script Size**: Performance with varying script lengths (10-200 lines)
+- **String Operations**: String concatenation and manipulation
+- **Function Calls**: Recursive function execution (e.g., Fibonacci)
+
+## Running Benchmarks
+
+### Run All Benchmarks
+
+```bash
+cargo bench
+```
+
+### Run Specific Benchmark Suite
+
+```bash
+# Tool operations only
+cargo bench --bench tool_operations
+
+# Protocol comparison only
+cargo bench --bench protocol_comparison
+
+# Codemode execution only
+cargo bench --bench codemode_execution
+```
+
+### Run Specific Benchmark
+
+```bash
+# Run only tool registration benchmarks
+cargo bench --bench tool_operations tool_registration
+
+# Run only search benchmarks with 100 tools
+cargo bench --bench tool_operations "tool_search/100"
+```
+
+### Generate Flamegraphs (Optional)
+
+Install cargo-flamegraph:
+```bash
+cargo install flamegraph
+```
+
+Run with flamegraph:
+```bash
+cargo bench --bench tool_operations -- --profile-time=5
+```
+
+## Interpreting Results
+
+Criterion generates HTML reports in `target/criterion/`. Open `target/criterion/report/index.html` in your browser to view:
+
+- **Throughput**: Operations per second
+- **Latency**: Time per operation (mean, median, std dev)
+- **Comparison**: Performance changes between runs
+- **Violin Plots**: Distribution of measurements
+- **Regression**: Historical performance tracking
+
+### Example Output
+
+```
+tool_registration/10    time:   [125.43 µs 127.89 µs 130.67 µs]
+tool_registration/50    time:   [623.21 µs 631.45 µs 640.89 µs]
+tool_registration/100   time:   [1.2534 ms 1.2689 ms 1.2851 ms]
+tool_registration/500   time:   [6.3421 ms 6.4123 ms 6.4891 ms]
+```
+
+## Performance Baselines
+
+Expected performance on a modern system (Apple M1/M2 or equivalent):
+
+| Operation | Size | Expected Time |
+|-----------|------|---------------|
+| Tool Registration | 100 tools | ~1-2 ms |
+| Tool Search | 100 tools | ~50-100 µs |
+| Client Init | Empty | ~100-200 µs |
+| Simple Script | 10 lines | ~50-100 µs |
+| CLI Tool Call | Echo | ~2-5 ms |
+
+## CI Integration
+
+Benchmarks can be run in CI to detect performance regressions:
+
+```yaml
+- name: Run benchmarks
+  run: cargo bench --no-fail-fast
+  
+- name: Upload benchmark results
+  uses: actions/upload-artifact@v4
+  with:
+    name: benchmark-results
+    path: target/criterion
+```
+
+## Optimizing Performance
+
+If you find slow performance:
+
+1. **Tool Registration**: Consider batching tool registrations
+2. **Search**: Use more specific tags to reduce search space
+3. **Codemode**: Keep scripts small and avoid deep recursion
+4. **Protocols**: Choose the right protocol for your use case:
+   - **CLI**: Fast for local tools
+   - **HTTP**: Good for REST APIs
+   - **gRPC**: Best for high-throughput RPC
+   - **MCP**: Ideal for stdio-based tools
+
+## Adding New Benchmarks
+
+To add a new benchmark:
+
+1. Create a new file in `benches/` or add to an existing one
+2. Use the Criterion API:
+
+```rust
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn my_benchmark(c: &mut Criterion) {
+    c.bench_function("my_operation", |b| {
+        b.iter(|| {
+            // Your code to benchmark
+            black_box(expensive_operation())
+        });
+    });
+}
+
+criterion_group!(benches, my_benchmark);
+criterion_main!(benches);
+```
+
+3. Add to `Cargo.toml`:
+
+```toml
+[[bench]]
+name = "my_benchmark"
+harness = false
+```
+
+## Resources
+
+- [Criterion.rs Documentation](https://bheisler.github.io/criterion.rs/book/)
+- [Rust Performance Book](https://nnethercote.github.io/perf-book/)
+- [Benchmarking Best Practices](https://easyperf.net/blog/)

--- a/benches/codemode_execution.rs
+++ b/benches/codemode_execution.rs
@@ -1,0 +1,375 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use rs_utcp::{
+    config::UtcpClientConfig,
+    plugins::codemode::{CodeModeUtcp, CodeModeArgs},
+    repository::in_memory::InMemoryToolRepository,
+    tag::tag_search::TagSearchStrategy,
+    UtcpClient,
+};
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+use serde_json::json;
+use tempfile::NamedTempFile;
+use std::fs;
+
+/// Helper to create a client from a config JSON
+async fn create_client_from_config(config_json: serde_json::Value) -> Arc<UtcpClient> {
+    let temp_file = NamedTempFile::new().unwrap();
+    fs::write(temp_file.path(), serde_json::to_vec(&config_json).unwrap()).unwrap();
+    
+    let config = UtcpClientConfig::new().with_providers_file(temp_file.path().to_path_buf());
+    let repo = Arc::new(InMemoryToolRepository::new());
+    let search = Arc::new(TagSearchStrategy::new(repo.clone(), 1.0));
+    
+    Arc::new(UtcpClient::new(config, repo, search).await.unwrap())
+}
+
+/// Benchmark basic Rhai script execution
+fn bench_simple_script_execution(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    
+    c.bench_function("codemode_simple_script", |b| {
+        let codemode = rt.block_on(async {
+            let config = UtcpClientConfig::new();
+            let repo = Arc::new(InMemoryToolRepository::new());
+            let search = Arc::new(TagSearchStrategy::new(repo.clone(), 1.0));
+            let client = UtcpClient::create(config, repo, search).await.unwrap();
+            
+            CodeModeUtcp::new(Arc::new(client))
+        });
+        
+        b.to_async(&rt).iter(|| async {
+            let script = "42 + 58";
+            let args = CodeModeArgs {
+                code: black_box(script.to_string()),
+                timeout: Some(5000),
+            };
+            
+            let result = codemode.execute(black_box(args)).await.unwrap();
+            black_box(result)
+        });
+    });
+}
+
+/// Benchmark script execution with different complexity levels
+fn bench_script_complexity(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("codemode_complexity");
+    
+    let codemode = rt.block_on(async {
+        let config = UtcpClientConfig::new();
+        let repo = Arc::new(InMemoryToolRepository::new());
+        let search = Arc::new(TagSearchStrategy::new(repo.clone(), 1.0));
+        let client = UtcpClient::create(config, repo, search).await.unwrap();
+        
+        CodeModeUtcp::new(Arc::new(client))
+    });
+    
+    // Simple arithmetic
+    group.bench_function("arithmetic", |b| {
+        b.to_async(&rt).iter(|| async {
+            let script = "let x = 10; let y = 20; x + y * 2";
+            let args = CodeModeArgs {
+                code: black_box(script.to_string()),
+                timeout: Some(5000),
+            };
+            
+            let result = codemode.execute(black_box(args)).await.unwrap();
+            black_box(result)
+        });
+    });
+    
+    // Loop execution
+    group.bench_function("loop_100", |b| {
+        b.to_async(&rt).iter(|| async {
+            let script = r#"
+                let sum = 0;
+                for i in 0..100 {
+                    sum += i;
+                }
+                sum
+            "#;
+            let args = CodeModeArgs {
+                code: black_box(script.to_string()),
+                timeout: Some(5000),
+            };
+            
+            let result = codemode.execute(black_box(args)).await.unwrap();
+            black_box(result)
+        });
+    });
+    
+    // Array operations
+    group.bench_function("array_operations", |b| {
+        b.to_async(&rt).iter(|| async {
+            let script = r#"
+                let arr = [];
+                for i in 0..50 {
+                    arr.push(i * 2);
+                }
+                arr.len()
+            "#;
+            let args = CodeModeArgs {
+                code: black_box(script.to_string()),
+                timeout: Some(5000),
+            };
+            
+            let result = codemode.execute(black_box(args)).await.unwrap();
+            black_box(result)
+        });
+    });
+    
+    // Map operations
+    group.bench_function("map_operations", |b| {
+        b.to_async(&rt).iter(|| async {
+            let script = r#"
+                let map = #{};
+                for i in 0..50 {
+                    map[`key_${i}`] = i * 2;
+                }
+                map.len()
+            "#;
+            let args = CodeModeArgs {
+                code: black_box(script.to_string()),
+                timeout: Some(5000),
+            };
+            
+            let result = codemode.execute(black_box(args)).await.unwrap();
+            black_box(result)
+        });
+    });
+    
+    group.finish();
+}
+
+/// Benchmark codemode call_tool function (key feature!)
+fn bench_codemode_call_tool(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    
+    c.bench_function("codemode_call_tool_cli", |b| {
+        let codemode = rt.block_on(async {
+            let config_json = json!({
+                "manual_call_templates": [{
+                    "call_template_type": "cli",
+                    "name": "test_provider",
+                    "command": "echo",
+                    "tools": [{
+                        "name": "greet",
+                        "description": "Greet someone",
+                        "inputs": {"type": "object"},
+                        "outputs": {"type": "object"},
+                        "tags": ["greeting"],
+                        "tool_call_template": {
+                            "call_template_type": "cli",
+                            "command": "echo",
+                            "args": ["Hello, {{name}}!"]
+                        }
+                    }]
+                }]
+            });
+            
+            let client = create_client_from_config(config_json).await;
+            CodeModeUtcp::new(client)
+        });
+        
+        b.to_async(&rt).iter(|| async {
+            // Script that calls a tool
+            let script = r#"
+                let result = call_tool("test_provider.greet", #{
+                    "name": "World"
+                });
+                result
+            "#;
+            let args = CodeModeArgs {
+                code: black_box(script.to_string()),
+                timeout: Some(5000),
+            };
+            
+            let result = codemode.execute(black_box(args)).await.unwrap();
+            black_box(result)
+        });
+    });
+}
+
+/// Benchmark multiple tool calls in sequence
+fn bench_codemode_multiple_tool_calls(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("codemode_multiple_calls");
+    
+    for call_count in [1, 3, 5].iter() {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(call_count),
+            call_count,
+            |b, &count| {
+                let codemode = rt.block_on(async {
+                    let config_json = json!({
+                        "manual_call_templates": [{
+                            "call_template_type": "cli",
+                            "name": "test_provider",
+                            "command": "echo",
+                            "tools": [{
+                                "name": "echo",
+                                "description": "Echo a message",
+                                "inputs": {"type": "object"},
+                                "outputs": {"type": "object"},
+                                "tags": ["utility"],
+                                "tool_call_template": {
+                                    "call_template_type": "cli",
+                                    "command": "echo",
+                                    "args": ["{{message}}"]
+                                }
+                            }]
+                        }]
+                    });
+                    
+                    let client = create_client_from_config(config_json).await;
+                    CodeModeUtcp::new(client)
+                });
+                
+                b.to_async(&rt).iter(|| async {
+                    // Generate script with multiple tool calls
+                    let mut script = String::from("let results = [];\n");
+                    for i in 0..count {
+                        script.push_str(&format!(
+                            "results.push(call_tool(\"test_provider.echo\", #{{\"message\": \"msg_{}\"}}));\n",
+                            i
+                        ));
+                    }
+                    script.push_str("results.len()");
+                    
+                    let args = CodeModeArgs {
+                        code: black_box(script),
+                        timeout: Some(10000),
+                    };
+                    
+                    let result = codemode.execute(black_box(args)).await.unwrap();
+                    black_box(result)
+                });
+            },
+        );
+    }
+    
+    group.finish();
+}
+
+/// Benchmark script parsing overhead
+fn bench_script_sizes(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("codemode_script_size");
+    
+    for line_count in [10, 50, 100, 200].iter() {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(line_count),
+            line_count,
+            |b, &count| {
+                let codemode = rt.block_on(async {
+                    let config = UtcpClientConfig::new();
+                    let repo = Arc::new(InMemoryToolRepository::new());
+                    let search = Arc::new(TagSearchStrategy::new(repo.clone(), 1.0));
+                    let client = UtcpClient::create(config, repo, search).await.unwrap();
+                    
+                    CodeModeUtcp::new(Arc::new(client))
+                });
+                
+                // Generate a script with many lines
+                let mut script = String::from("let sum = 0;\n");
+                for i in 0..count {
+                    script.push_str(&format!("sum += {};\n", i));
+                }
+                script.push_str("sum");
+                
+                b.to_async(&rt).iter(|| async {
+                    let args = CodeModeArgs {
+                        code: black_box(script.clone()),
+                        timeout: Some(10000),
+                    };
+                    
+                    let result = codemode.execute(black_box(args)).await.unwrap();
+                    black_box(result)
+                });
+            },
+        );
+    }
+    
+    group.finish();
+}
+
+/// Benchmark string operations in Rhai
+fn bench_string_operations(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    
+    c.bench_function("codemode_string_concat", |b| {
+        let codemode = rt.block_on(async {
+            let config = UtcpClientConfig::new();
+            let repo = Arc::new(InMemoryToolRepository::new());
+            let search = Arc::new(TagSearchStrategy::new(repo.clone(), 1.0));
+            let client = UtcpClient::create(config, repo, search).await.unwrap();
+            
+            CodeModeUtcp::new(Arc::new(client))
+        });
+        
+        b.to_async(&rt).iter(|| async {
+            let script = r#"
+                let result = "";
+                for i in 0..20 {
+                    result += `item_${i}_`;
+                }
+                result
+            "#;
+            let args = CodeModeArgs {
+                code: black_box(script.to_string()),
+                timeout: Some(5000),
+            };
+            
+            let result = codemode.execute(black_box(args)).await.unwrap();
+            black_box(result)
+        });
+    });
+}
+
+/// Benchmark function definitions and calls
+fn bench_function_calls(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    
+    c.bench_function("codemode_function_calls", |b| {
+        let codemode = rt.block_on(async {
+            let config = UtcpClientConfig::new();
+            let repo = Arc::new(InMemoryToolRepository::new());
+            let search = Arc::new(TagSearchStrategy::new(repo.clone(), 1.0));
+            let client = UtcpClient::create(config, repo, search).await.unwrap();
+            
+            CodeModeUtcp::new(Arc::new(client))
+        });
+        
+        b.to_async(&rt).iter(|| async {
+            let script = r#"
+                fn fibonacci(n) {
+                    if n <= 1 {
+                        return n;
+                    }
+                    return fibonacci(n - 1) + fibonacci(n - 2);
+                }
+                fibonacci(10)
+            "#;
+            let args = CodeModeArgs {
+                code: black_box(script.to_string()),
+                timeout: Some(5000),
+            };
+            
+            let result = codemode.execute(black_box(args)).await.unwrap();
+            black_box(result)
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_simple_script_execution,
+    bench_script_complexity,
+    bench_codemode_call_tool,
+    bench_codemode_multiple_tool_calls,
+    bench_script_sizes,
+    bench_string_operations,
+    bench_function_calls,
+);
+criterion_main!(benches);

--- a/benches/protocol_comparison.rs
+++ b/benches/protocol_comparison.rs
@@ -1,0 +1,224 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rs_utcp::{
+    config::UtcpClientConfig,
+    repository::in_memory::InMemoryToolRepository,
+    tag::tag_search::TagSearchStrategy,
+    UtcpClient, UtcpClientInterface,
+};
+use std::{collections::HashMap, sync::Arc};
+use tokio::runtime::Runtime;
+use serde_json::json;
+use tempfile::NamedTempFile;
+use std::fs;
+
+/// Helper to create a client from a config JSON
+async fn create_client_from_config(config_json: serde_json::Value) -> Arc<UtcpClient> {
+    let temp_file = NamedTempFile::new().unwrap();
+    fs::write(temp_file.path(), serde_json::to_vec(&config_json).unwrap()).unwrap();
+    
+    let config = UtcpClientConfig::new().with_providers_file(temp_file.path().to_path_buf());
+    let repo = Arc::new(InMemoryToolRepository::new());
+    let search = Arc::new(TagSearchStrategy::new(repo.clone(), 1.0));
+    
+    Arc::new(UtcpClient::new(config, repo, search).await.unwrap())
+}
+
+/// Benchmark CLI tool calling (actual execution)
+fn bench_cli_tool_call(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    
+    c.bench_function("cli_echo_call", |b| {
+        let client = rt.block_on(async {
+            let config_json = json!({
+                "manual_call_templates": [{
+                    "call_template_type": "cli",
+                    "name": "echo_provider",
+                    "command": "echo",
+                    "tools": [{
+                        "name": "echo",
+                        "description": "Echo a message",
+                        "inputs": {"type": "object"},
+                        "outputs": {"type": "object"},
+                        "tags": ["utility"],
+                        "tool_call_template": {
+                            "call_template_type": "cli",
+                            "command": "echo",
+                            "args": ["{{message}}"]
+                        }
+                    }]
+                }]
+            });
+            
+            create_client_from_config(config_json).await
+        });
+        
+        b.to_async(&rt).iter(|| async {
+            let mut args = HashMap::new();
+            args.insert("message".to_string(), json!("benchmark"));
+            
+            let _ = client.call_tool(black_box("echo_provider.echo"), black_box(args)).await;
+        });
+    });
+}
+
+/// Compare provider initialization overhead across different types
+fn bench_provider_comparison(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("provider_initialization");
+    
+    // HTTP Provider
+    group.bench_function("http", |b| {
+        b.to_async(&rt).iter(|| async {
+            let config_json = json!({
+                "manual_call_templates": [{
+                    "call_template_type": "http",
+                    "name": "http_test",
+                    "url": "http://localhost:9999/tools",
+                    "http_method": "GET"
+                }]
+            });
+            
+            let client = create_client_from_config(black_box(config_json)).await;
+            black_box(client)
+        });
+    });
+    
+    // CLI Provider
+    group.bench_function("cli", |b| {
+        b.to_async(&rt).iter(|| async {
+            let config_json = json!({
+                "manual_call_templates": [{
+                    "call_template_type": "cli",
+                    "name": "cli_test",
+                    "command": "echo"
+                }]
+            });
+            
+            let client = create_client_from_config(black_box(config_json)).await;
+            black_box(client)
+        });
+    });
+    
+    // WebSocket Provider (registration only, no connection)
+    group.bench_function("websocket", |b| {
+        b.to_async(&rt).iter(|| async {
+            let config_json = json!({
+                "manual_call_templates": [{
+                    "call_template_type": "websocket",
+                    "name": "ws_test",
+                    "url": "ws://localhost:9999"
+                }]
+            });
+            
+            let client = create_client_from_config(black_box(config_json)).await;
+            black_box(client)
+        });
+    });
+    
+    // MCP Provider
+    group.bench_function("mcp", |b| {
+        b.to_async(&rt).iter(|| async {
+            let config_json = json!({
+                "manual_call_templates": [{
+                    "call_template_type": "mcp",
+                    "name": "mcp_test",
+                    "command": "python3",
+                    "args": ["server.py"]
+                }]
+            });
+            
+            let client = create_client_from_config(black_box(config_json)).await;
+            black_box(client)
+        });
+    });
+    
+    // gRPC Provider
+    group.bench_function("grpc", |b| {
+        b.to_async(&rt).iter(|| async {
+            let config_json = json!({
+                "manual_call_templates": [{
+                    "call_template_type": "grpc",
+                    "name": "grpc_test",
+                    "url": "http://localhost:9999"
+                }]
+            });
+            
+            let client = create_client_from_config(black_box(config_json)).await;
+            black_box(client)
+        });
+    });
+    
+    // SSE Provider
+    group.bench_function("sse", |b| {
+        b.to_async(&rt).iter(|| async {
+            let config_json = json!({
+                "manual_call_templates": [{
+                    "call_template_type": "sse",
+                    "name": "sse_test",
+                    "url": "http://localhost:9999/events"
+                }]
+            });
+            
+            let client = create_client_from_config(black_box(config_json)).await;
+            black_box(client)
+        });
+    });
+    
+    group.finish();
+}
+
+/// Benchmark loading multiple providers at once
+fn bench_multi_provider_loading(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    
+    c.bench_function("load_6_providers", |b| {
+        b.to_async(&rt).iter(|| async {
+            let config_json = json!({
+                "manual_call_templates": [
+                    {
+                        "call_template_type": "http",
+                        "name": "http_provider",
+                        "url": "http://localhost:8001/tools"
+                    },
+                    {
+                        "call_template_type": "cli",
+                        "name": "cli_provider",
+                        "command": "echo"
+                    },
+                    {
+                        "call_template_type": "websocket",
+                        "name": "ws_provider",
+                        "url": "ws://localhost:8002"
+                    },
+                    {
+                        "call_template_type": "mcp",
+                        "name": "mcp_provider",
+                        "command": "python3",
+                        "args": ["server.py"]
+                    },
+                    {
+                        "call_template_type": "grpc",
+                        "name": "grpc_provider",
+                        "url": "http://localhost:8003"
+                    },
+                    {
+                        "call_template_type": "sse",
+                        "name": "sse_provider",
+                        "url": "http://localhost:8004/events"
+                    }
+                ]
+            });
+            
+            let client = create_client_from_config(black_box(config_json)).await;
+            black_box(client)
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_cli_tool_call,
+    bench_provider_comparison,
+    bench_multi_provider_loading,
+);
+criterion_main!(benches);

--- a/benches/tool_operations.rs
+++ b/benches/tool_operations.rs
@@ -1,0 +1,222 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use rs_utcp::{
+    config::UtcpClientConfig,
+    repository::in_memory::InMemoryToolRepository,
+    tag::tag_search::TagSearchStrategy,
+    UtcpClient, UtcpClientInterface,
+};
+use std::{collections::HashMap, sync::Arc};
+use serde_json::json;
+use tokio::runtime::Runtime;
+use tempfile::NamedTempFile;
+use std::fs;
+
+/// Helper function to create a client with tools from config
+async fn create_client_with_tools(tool_count: usize) -> Arc<UtcpClient> {
+    let mut tools = vec![];
+    for i in 0..tool_count {
+        tools.push(json!({
+            "name": format!("tool_{}", i),
+            "description": format!("Description for tool {}", i),
+            "inputs": {"type": "object"},
+            "outputs": {"type": "object"},
+            "tags": [
+                format!("category_{}", i % 5),
+                format!("type_{}", i % 3),
+                "common"
+            ]
+        }));
+    }
+    
+    let config_content = json!({
+        "manual_call_templates": [{
+            "call_template_type": "cli",
+            "name": "test_provider",
+            "command": "echo",
+            "tools": tools
+        }]
+    });
+    
+    let temp_file = NamedTempFile::new().unwrap();
+    fs::write(temp_file.path(), serde_json::to_vec(&config_content).unwrap()).unwrap();
+    
+    let config = UtcpClientConfig::new().with_providers_file(temp_file.path().to_path_buf());
+    let repo = Arc::new(InMemoryToolRepository::new());
+    let search = Arc::new(TagSearchStrategy::new(repo.clone(), 1.0));
+    
+    Arc::new(UtcpClient::new(config, repo, search).await.unwrap())
+}
+
+/// Benchmark tool search performance with different repository sizes
+fn bench_tool_search(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("tool_search");
+
+    for tool_count in [10, 50, 100, 500].iter() {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(tool_count),
+            tool_count,
+            |b, &count| {
+                let client = rt.block_on(create_client_with_tools(count));
+
+                b.to_async(&rt).iter(|| async {
+                    let results = client
+                        .search_tools(black_box("category_2"), black_box(10))
+                        .await
+                        .unwrap();
+                    black_box(results)
+               });
+            },
+        );
+    }
+    
+    group.finish();
+}
+
+/// Benchmark client initialization with different configurations
+fn bench_client_initialization(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    
+    c.bench_function("client_init_empty", |b| {
+        b.to_async(&rt).iter(|| async {
+            let config = UtcpClientConfig::new();
+            let repo = Arc::new(InMemoryToolRepository::new());
+            let search = Arc::new(TagSearchStrategy::new(repo.clone(), 1.0));
+            
+            let client = UtcpClient::create(
+                black_box(config),
+                black_box(repo),
+                black_box(search),
+            )
+            .await
+            .unwrap();
+            
+            black_box(client)
+        });
+    });
+}
+
+/// Benchmark tool calling with different argument sizes
+fn bench_tool_call_overhead(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("tool_call_overhead");
+
+    for arg_count in [0, 5, 10, 20].iter() {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(arg_count),
+            arg_count,
+            |b, &count| {
+                let client = rt.block_on(async {
+                    let config_content = json!({
+                        "manual_call_templates": [{
+                            "call_template_type": "cli",
+                            "name": "test_provider",
+                            "command": "echo",
+                            "tools": [{
+                                "name": "echo",
+                                "description": "Echo tool",
+                                "inputs": {"type": "object"},
+                                "outputs": {"type": "object"},
+                                "tags": ["test"]
+                            }]
+                        }]
+                    });
+                    
+                    let temp_file = NamedTempFile::new().unwrap();
+                    fs::write(temp_file.path(), serde_json::to_vec(&config_content).unwrap()).unwrap();
+                    
+                    let config = UtcpClientConfig::new().with_providers_file(temp_file.path().to_path_buf());
+                    let repo = Arc::new(InMemoryToolRepository::new());
+                    let search = Arc::new(TagSearchStrategy::new(repo.clone(), 1.0));
+                    
+                    Arc::new(UtcpClient::new(config, repo, search).await.unwrap())
+                });
+
+                b.to_async(&rt).iter(|| async {
+                    let mut args = HashMap::new();
+                    for i in 0..count {
+                        args.insert(
+                            format!("arg_{}", i),
+                            serde_json::json!(format!("value_{}", i)),
+                        );
+                    }
+                    
+                    // Call the echo tool
+                    let _ = client.call_tool(black_box("test_provider.echo"), black_box(args)).await;
+                });
+            },
+        );
+    }
+    
+    group.finish();
+}
+
+/// Benchmark tag matching algorithm performance
+fn bench_tag_matching(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("tag_matching");
+
+    for tag_count in [2, 5, 10, 20].iter() {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(tag_count),
+            tag_count,
+            |b, &count| {
+                let client = rt.block_on(async {
+                    // Create 100 tools with varying tag counts
+                    let mut tools = vec![];
+                    for i in 0..100 {
+                        let mut tags = vec![];
+                        for j in 0..count {
+                            tags.push(format!("tag_{}_{}", i % 10, j));
+                        }
+                        
+                        tools.push(json!({
+                            "name": format!("tool_{}", i),
+                            "description": format!("Tool {}", i),
+                            "inputs": {"type": "object"},
+                            "outputs": {"type": "object"},
+                            "tags": tags
+                        }));
+                    }
+                    
+                    let config_content = json!({
+                        "manual_call_templates": [{
+                            "call_template_type": "cli",
+                            "name": "test_provider",
+                            "command": "echo",
+                            "tools": tools
+                        }]
+                    });
+                    
+                    let temp_file = NamedTempFile::new().unwrap();
+                    fs::write(temp_file.path(), serde_json::to_vec(&config_content).unwrap()).unwrap();
+                    
+                    let config = UtcpClientConfig::new().with_providers_file(temp_file.path().to_path_buf());
+                    let repo = Arc::new(InMemoryToolRepository::new());
+                    let search = Arc::new(TagSearchStrategy::new(repo.clone(), 1.0));
+                    
+                    Arc::new(UtcpClient::new(config, repo, search).await.unwrap())
+                });
+
+                b.to_async(&rt).iter(|| async {
+                    let results = client
+                        .search_tools(black_box("tag_5"), black_box(10))
+                        .await
+                        .unwrap();
+                    black_box(results)
+                });
+            },
+        );
+    }
+    
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_tool_search,
+    bench_client_initialization,
+    bench_tool_call_overhead,
+    bench_tag_matching,
+);
+criterion_main!(benches);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Criterion-based benchmarks to measure rs-utcp performance across tool operations, protocol overhead, and codemode execution, with HTML reports and easy runs via cargo bench.

- **New Features**
  - Added three benchmark suites: tool_operations, protocol_comparison, codemode_execution.
  - Included benches/README.md with run commands, report locations, and CI tips.
  - Registered benches in Cargo.toml (harness = false) for fast execution.

- **Dependencies**
  - Added criterion (features: async_tokio, html_reports).
  - Bumped crate version to 0.2.4.
  - Updated Cargo.lock with transitive deps used by benchmarks.

<sup>Written for commit cb77cef4300afbca013e52b9c9b85fded0be59b3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

