### PR TITLE
feat: fix security issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - 2025-11-29
+
+### Security
+- **Transport Security Integration**:
+  - Enforced URL security (HTTPS/TLS) in HTTP, WebRTC, and MCP transports.
+  - Enforced response size limits (10MB) in HTTP, WebRTC, and MCP transports to prevent DoS.
+  - Added message size validation for WebRTC data channels.
+  - Enforced path traversal protection in Text transport (validates script and tool paths).
+
+### Fixed
+- Fixed unused variable warning in WebRTC transport.
+
 ## [0.2.5] - 2025-11-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2274,7 +2274,7 @@ dependencies = [
 
 [[package]]
 name = "rs-utcp"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs-utcp"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 description = "Rust implementation of the Universal Tool Calling Protocol (UTCP)."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enforces transport-level security across HTTP, MCP, WebRTC, and Text providers to block unsafe URLs, oversized responses, and path traversal. Also adds WebRTC message size checks, fixes an unused variable warning, and bumps the crate to 0.2.6.

- **Security**
  - Require HTTPS/TLS and validate URLs in HTTP, MCP, and WebRTC.
  - Enforce 10MB response/message limits for HTTP, MCP, and WebRTC.
  - Validate file and script paths in Text transport to prevent path traversal.
  - Validate MCP stdio commands and args to reduce injection risk.

<sup>Written for commit 80e70d4fe8ed9a916cbc88120856ded21fe6fa77. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

